### PR TITLE
Add Form section pattern

### DIFF
--- a/app/src/Pages/ChangePassword/ChangePassword.js
+++ b/app/src/Pages/ChangePassword/ChangePassword.js
@@ -27,14 +27,15 @@ const ChangePassword = () => (
         }}
       >
         {({
-          form,
+          formSections,
           isValid,
           handleCancel,
           handleSubmit /* isDirty, isSubmitting */
         }) => (
           <React.Fragment>
             <p css={formTitle}>Change Password</p>
-            {form}
+            {formSections.oldPassword}
+            {formSections.newPassword}
             <div css={buttonWrapper}>
               <Button
                 buttonType="cancel"

--- a/app/src/components/Forms/ChangePassword.js
+++ b/app/src/components/Forms/ChangePassword.js
@@ -7,6 +7,7 @@ import PasswordField from "../Fields/PasswordField";
 const fields = {
   oldPassword: {
     label: "Old Password",
+    section: "oldPassword",
     component: PasswordField,
     validation: Yup.string("What was you old password").required(
       "What was your old password"
@@ -14,6 +15,7 @@ const fields = {
   },
   newPassword: {
     label: "New Password",
+    section: "newPassword",
     component: PasswordField,
     validation: Yup.string("Choose a new password").required(
       "Password is required"
@@ -21,6 +23,7 @@ const fields = {
   },
   confirmNewPassword: {
     label: "Confirm New Password",
+    section: "newPassword",
     component: PasswordField,
     validation: Yup.string("Choose a new password that matches the other one")
       .oneOf([Yup.ref("newPassword"), null], "Passwords must match")
@@ -29,7 +32,7 @@ const fields = {
 };
 
 const ChangePasswordForm = ({ initialValues, onSubmit, children }) => (
-  <Form fields={fields} initialValues={initialValues} onSubmit={onSubmit}>
+  <Form fields={fields} sections={["oldPassword", "newPassword"]} initialValues={initialValues} onSubmit={onSubmit}>
     {children}
   </Form>
 );

--- a/app/src/components/Forms/Form.js
+++ b/app/src/components/Forms/Form.js
@@ -4,11 +4,8 @@ import { Formik } from "formik";
 import * as Yup from "yup";
 
 const submitHandler = (values, formikBag) => {
-<<<<<<< Updated upstream
-=======
   // This is a work around to be able to encapsulate
   // attaching state handling upon submission within the form.
->>>>>>> Stashed changes
   const addHandlers = promise =>
     promise.then(
       result => {

--- a/app/src/components/Forms/Form.js
+++ b/app/src/components/Forms/Form.js
@@ -4,6 +4,11 @@ import { Formik } from "formik";
 import * as Yup from "yup";
 
 const submitHandler = (values, formikBag) => {
+<<<<<<< Updated upstream
+=======
+  // This is a work around to be able to encapsulate
+  // attaching state handling upon submission within the form.
+>>>>>>> Stashed changes
   const addHandlers = promise =>
     promise.then(
       result => {
@@ -20,11 +25,25 @@ const submitHandler = (values, formikBag) => {
   return this.props.onSubmit(values, addHandlers);
 };
 
+const formFromFields = (fields, formikProps) =>
+  Object.keys(fields).map(id =>
+    React.createElement(fields[id].component, {
+      id,
+      label: fields[id].label,
+      formik: formikProps
+    })
+  );
+
 class Form extends React.Component {
   render() {
-    const { fields, initialValues, children } = this.props;
+    const { fields, initialValues, sections, children } = this.props;
     const fieldIds = Object.keys(fields);
-    const validations = Object.fromEntries(fieldIds.map(id => [id, fields[id].validation]));
+    const validations = Object.fromEntries(
+      fieldIds.map(id => [id, fields[id].validation])
+    );
+    const sectionFields = Object.fromEntries(
+      fieldIds.map(id => [id, fields[id].section])
+    );
     const validationSchema = Yup.object(validations);
     return (
       <Formik
@@ -35,18 +54,21 @@ class Form extends React.Component {
         render={formikProps => {
           const form = (
             <React.Fragment>
-              {Object.keys(fields).map(id =>
-                React.createElement(fields[id].component, {
-                  id,
-                  label: fields[id].label,
-                  formik: formikProps
-                })
-              )}
+              {formFromFields(fields, formikProps)}
             </React.Fragment>
           );
-
+          const formSections =
+            sections && sections.length > 0
+              ? Object.fromEntries(
+                  sections.map(section => [
+                    section,
+                    fields.filter(field => field.section == section)
+                  ])
+                )
+              : {};
           return children({
             form,
+            formSections,
             isValid: formikProps.isValid,
             // isDirty: formikProps.dirty,
             // isSubmitting: formikProps.isSubmitting,
@@ -64,7 +86,10 @@ Form.propTypes = {
     PropTypes.shape({
       label: PropTypes.string,
       component: PropTypes.component,
-      validation: PropTypes.shape({/* Yup validation */})
+      validation: PropTypes.shape({
+        /* Yup validation */
+      }),
+      // section: PropTypes.arrayOf(PropTypes.string) <- optional
     })
   ).isRequired,
   initialValues: PropTypes.shape({}).isRequired,

--- a/app/src/components/Forms/Form.js
+++ b/app/src/components/Forms/Form.js
@@ -26,6 +26,7 @@ const submitHandler = (values, formikBag) => {
 const formFromFields = (fields, formikProps) =>
   Object.keys(fields).map(id =>
     React.createElement(fields[id].component, {
+      key: id,
       id,
       label: fields[id].label,
       formik: formikProps

--- a/app/src/components/Forms/Form.js
+++ b/app/src/components/Forms/Form.js
@@ -39,9 +39,6 @@ class Form extends React.Component {
     const validations = Object.fromEntries(
       fieldIds.map(id => [id, fields[id].validation])
     );
-    const sectionFields = Object.fromEntries(
-      fieldIds.map(id => [id, fields[id].section])
-    );
     const validationSchema = Yup.object(validations);
     return (
       <Formik
@@ -95,7 +92,7 @@ Form.propTypes = {
       validation: PropTypes.shape({
         /* Yup validation */
       })
-      // section: PropTypes.arrayOf(PropTypes.string) <- optional
+      // sections: PropTypes.arrayOf(PropTypes.string) <- optional
     })
   ).isRequired,
   initialValues: PropTypes.shape({}).isRequired,

--- a/app/src/components/Forms/Form.js
+++ b/app/src/components/Forms/Form.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Formik } from "formik";
 import * as Yup from "yup";
+import _ from "lodash";
 
 const submitHandler = (values, formikBag) => {
   // This is a work around to be able to encapsulate
@@ -59,7 +60,15 @@ class Form extends React.Component {
               ? Object.fromEntries(
                   sections.map(section => [
                     section,
-                    fields.filter(field => field.section == section)
+                    <React.Fragment>
+                      {formFromFields(
+                        _.pickBy(
+                          fields,
+                          field => field.section === section
+                        ),
+                        formikProps
+                      )}
+                    </React.Fragment>
                   ])
                 )
               : {};
@@ -85,7 +94,7 @@ Form.propTypes = {
       component: PropTypes.component,
       validation: PropTypes.shape({
         /* Yup validation */
-      }),
+      })
       // section: PropTypes.arrayOf(PropTypes.string) <- optional
     })
   ).isRequired,

--- a/app/src/components/Forms/Form.test.js
+++ b/app/src/components/Forms/Form.test.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { Form } from "./Form";
+
+describe("<Form />", () => {
+  it("should be defined", () => {
+    expect(Form).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This demonstrates a potential pattern for form sections. It also shows an example using ChangePassword.

If you pass a an array of section names as a prop to Form, then it will give you back a formSections object.

Like so:
```
// each field in the fields object has a section, either of the following
// section: "userInfo"
// section: "passwordInfo"

<Form fields={fields} sections={["userInfo","passwordInfo"]} ...>
```

Then in the form page, where you'd use `form`, instead you'd use `formSections.userInfo` and `formSections.passwordInfo`.

Next steps are:
- [ ] add tests
- [ ] update readme
