### PR TITLE
Changes NODE_ENV from develop to development Closes: #362

### DIFF
--- a/api/models/db.ts
+++ b/api/models/db.ts
@@ -15,7 +15,7 @@ export default async (): Promise<Connection> => {
             __dirname + '/entity/*.ts'
         ],
         synchronize: true,
-        logging: process.env.NODE_ENV === 'develop'
+        logging: process.env.NODE_ENV === 'development'
     });
 
     return connection;

--- a/api/services/emailService.ts
+++ b/api/services/emailService.ts
@@ -160,7 +160,7 @@ export async function sendInvitationEmail(params: ISendInvitationEmailAttrs) {
 
 export async function sendEmail(params: ISESEmailParams): Promise<ISESEmailParams> {
   if (process.env.NODE_ENV === 'test') {
-  } else if (process.env.NODE_ENV === 'develop') {
+  } else if (process.env.NODE_ENV === 'development') {
     console.log('In develop mode, this email is not sent ', params);
   } else {
     if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -50,7 +50,7 @@ export const ContributionStatusEnum = Object.freeze({
 export function baseUrl() {
   if (process.env.NODE_ENV === "test") {
     return "http://localhost:3000";
-  } else if (process.env.NODE_ENV === "develop") {
+  } else if (process.env.NODE_ENV === "development") {
     return "http://localhost:3000";
   } else if (process.env.NODE_ENV === "staging") {
     return "https://api.qa.openelectinosports.org";

--- a/app/src/api/api.test.js
+++ b/app/src/api/api.test.js
@@ -56,7 +56,7 @@ describe("API", () => {
 
   it("baseUrl", async function() {
     expect(api.baseUrl()).toEqual("http://localhost:3000");
-    process.env.NODE_ENV = "develop";
+    process.env.NODE_ENV = "development";
     expect(api.baseUrl()).toEqual("http://localhost:3000");
     process.env.NODE_ENV = "staging";
     expect(api.baseUrl()).toEqual("https://api.qa.openelectinosports.org");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     command: ["npm", "start"]
     environment:
       - PORT=4000
-      - NODE_ENV=develop
     depends_on:
       - db
     ports:


### PR DESCRIPTION
Change references in in code to the NODE_ENV from develop to developer
`process.env.NODE_ENV === 'develop' `   
changes to
`process.env.NODE_ENV === 'development'`

See #362 