### PR TITLE
prevent date format from displaying over top of field label

### DIFF
--- a/app/src/components/Fields/DateField.js
+++ b/app/src/components/Fields/DateField.js
@@ -15,6 +15,7 @@ const DateField = ({ id, label, formik }) => (
     onBlur={formik.handleBlur}
     autoComplete="on"
     fullWidth
+    InputLabelProps={{ shrink: true }}
   />
 );
 


### PR DESCRIPTION
added prop to prevent date format from displaying over label when no value

- previously label & date format overwrote each other if no value for TextField
- from https://github.com/mui-org/material-ui/issues/8131:
when date picker has no value and is going to display the expected
date format in the field, it should treat that as a value and move the
label up to superscript.

<img width="733" alt="Screen Shot 2019-07-10 at 2 53 43 PM" src="https://user-images.githubusercontent.com/6107653/61007814-aee57680-a322-11e9-943e-e784f956fbb4.png">

<img width="695" alt="Screen Shot 2019-07-10 at 2 53 21 PM" src="https://user-images.githubusercontent.com/6107653/61007815-b147d080-a322-11e9-8e5e-75181b6142cb.png">

