### PR TITLE
make default sign-in values empty strings

### DIFF
--- a/app/src/components/Forms/SignIn/index.js
+++ b/app/src/components/Forms/SignIn/index.js
@@ -28,8 +28,8 @@ const forgotLink = css`
       }
     }
       initialValues={{
-        email: "govadmin@openelectionsportland.org",
-        password: "passwordd" 
+        email: "",
+        password: "" 
       }}
     >
       {({


### PR DESCRIPTION
this commit removes the default login and (incorrect) password from the sign-in page