### PR TITLE
Map campaign name to selector

### DIFF
--- a/app/src/state/ducks/campaigns.js
+++ b/app/src/state/ducks/campaigns.js
@@ -81,8 +81,12 @@ export const getCampaignInfo = createSelector(
   state => state.campaigns
 );
 
+//Assumes one campaign
 export const getCampaignName = state => {
-  return getCampaignInfo(state).name
-    ? getCampaignInfo(state).name
-    : "No Campaign Name";
+  const id = (getCampaignInfo(state).currentCampaignId)
+    ? getCampaignInfo(state).currentCampaignId
+    : 0;
+  return getCampaignInfo(state)[id]
+    ? getCampaignInfo(state)[id].name
+    : "Campaign";
 };


### PR DESCRIPTION
Looks for the first campaign in the array and passes back the name. Does not get the state until manage portal is loaded.  Fetch default campaign users on login? 