### PR TITLE
Fix styling of remove user modal-  GH 442

### DIFF
--- a/app/src/Pages/Portal/ManagePortal/ManageUser/ManageUser.js
+++ b/app/src/Pages/Portal/ManagePortal/ManageUser/ManageUser.js
@@ -61,7 +61,7 @@ const ManageUserPage = props => {
           )}
         </div>
         <div className="manage-user-role" css={divSpacer}>
-          <h2>Mangage Role</h2>
+          <h2>Manage Role</h2>
         </div>
         <div className="remove-user">
           <Button

--- a/app/src/components/Forms/RemoveUser/RemoveUser.js
+++ b/app/src/components/Forms/RemoveUser/RemoveUser.js
@@ -7,7 +7,8 @@ import FormModal from "../../FormModal/FormModal";
 import { css, jsx } from "@emotion/core";
 
 const removeUserStyle = css`
-  padding: 40px;
+  word-break: break-word;
+  max-width:300px;
 `;
 const buttonContainer = css`
   display: flex;
@@ -17,7 +18,7 @@ const buttonContainer = css`
   }
 `;
 const removeUserTitle = css`
-  font-size: 20px;
+  font-size: 36px;
 `;
 
 const RemoveUser = (props) => {

--- a/app/src/components/Forms/RemoveUser/RemoveUser.js
+++ b/app/src/components/Forms/RemoveUser/RemoveUser.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from "react-redux";
-import Button from '../../Button/Button'
+import Button from "../../../components/Button/Button";
 import { getModalState, clearModal } from "../../../state/ducks/modal";
 import FormModal from "../../FormModal/FormModal";
 /** @jsx jsx */
@@ -11,13 +11,13 @@ const removeUserStyle = css`
 `;
 const buttonContainer = css`
   display: flex;
-  flex-direction: row;
   margin-top: 30px;
-  align-items: center;
-  justify-content: space-around;
   button {
     margin: 10px;
   }
+`;
+const removeUserTitle = css`
+  font-size: 20px;
 `;
 
 const RemoveUser = (props) => {
@@ -25,14 +25,14 @@ const RemoveUser = (props) => {
   return (
     <FormModal>
     <div css={removeUserStyle}>
+      <h1 css={removeUserTitle}>Remove User </h1>
       <p>{props.location.state.email} will no longer have access to the portal.</p>
       <p>Are you sure you want to remove them?</p>
       <div css={buttonContainer}>
         <Button buttonType="formDefaultOutlined" onClick={() => props.clearModal()}>
           Cancel
             </Button>
-        <Button
-          buttonType="formDefault" onClick={
+        <Button buttonType="formDefault" onClick={
             () => props.removeUser(props.location.state.id, props.location.state.roleId)
             }>
           Submit


### PR DESCRIPTION
This PR closes #442 

Makes content fit within the remove user modal:

    - set maxWidth of content to less than modal maxWidth
    - set word-break to alleviate overflow of long email addresses
    - removed unneeded flex styling that was causing squashing of button

Also, fixes a small typo I happened to catch (`Mangage` changed to `Manage` 😀 )