### PR TITLE
Fix Add Campaign Form placeholder GH #525

### DIFF
--- a/app/src/components/Forms/AddCampaign/index.js
+++ b/app/src/components/Forms/AddCampaign/index.js
@@ -45,6 +45,7 @@ const AddCampaign = props => (
       }}
       initialValues={{
         name: "",
+        officeSought: "",
         email: "",
         firstName: "",
         lastName: ""


### PR DESCRIPTION
Adds missing initial value field to form. Resolves #525 