### PR TITLE
WIP- Bug/wonky buttons gh 557

### DIFF
--- a/app/src/components/Button/Button.js
+++ b/app/src/components/Button/Button.js
@@ -7,7 +7,9 @@ import MaterialButton from "@material-ui/core/Button";
 // To add a custom button style, you can create a new buttonType and style. Emotion was not overriding material :(
 const manageStyle = {
   border: "1px solid #5F5FFF",
-  color: "#5F5FFF"
+  color: "#5F5FFF",
+  borderRadius: "5px",
+  padding: "6px 16px"
 };
 
 const formDefaultStyle = {
@@ -18,15 +20,18 @@ const formDefaultStyle = {
   fontStyle: "normal",
   fontWeight: "normal",
   fontSize: "16px",
-  lineHeight: "19px"
+  lineHeight: "19px",
+  borderRadius: "5px",
+  padding: "6px 16px"
 }
 
 const formDefaultOutlinedStyle = {
   border: "1px solid #5F5FFF",
   color: "#5F5FFF",
   padding: "10px 20px",
-  textTransform: "none"
-
+  textTransform: "none",
+  borderRadius: "5px",
+  padding: "6px 16px"
 };
 
 const primaryOverrides = {
@@ -38,7 +43,9 @@ const primaryOverrides = {
   fontWeight: "normal",
   fontSize: "16px",
   lineHeight: "19px",
-  padding: "10px 20px !important"
+  padding: "10px 20px !important",
+  borderRadius: "5px",
+  padding: "6px 16px"
 };
 
 const remove = {
@@ -49,12 +56,16 @@ const remove = {
   fontStyle: "normal",
   fontWeight: "normal",
   fontSize: "16px",
-  lineHeight: "19px"
+  lineHeight: "19px",
+  borderRadius: "5px",
+  padding: "6px 16px"
 };
 
 const greenStyle = {
   backgroundColor: "#42B44A",
-  color: "#fff"
+  color: "#fff",
+  borderRadius: "5px",
+  padding: "6px 16px"
 };
 
 const buttonTypes = {

--- a/app/src/components/Button/Button.js
+++ b/app/src/components/Button/Button.js
@@ -9,6 +9,7 @@ const manageStyle = {
   border: "1px solid #5F5FFF",
   color: "#5F5FFF",
   borderRadius: "5px",
+  lineHeight: "17px",
   padding: "6px 16px"
 };
 
@@ -28,7 +29,11 @@ const formDefaultStyle = {
 const formDefaultOutlinedStyle = {
   border: "1px solid #5F5FFF",
   color: "#5F5FFF",
-  padding: "10px 20px",
+  fontFamily: "Rubik",
+  fontStyle: "normal",
+  fontWeight: "normal",
+  lineHeight: "17px",
+  fontSize: "16px",
   textTransform: "none",
   borderRadius: "5px",
   padding: "6px 16px"
@@ -43,7 +48,7 @@ const primaryOverrides = {
   fontWeight: "normal",
   fontSize: "16px",
   lineHeight: "19px",
-  padding: "10px 20px !important",
+  // padding: "10px 20px !important",  // need to check where this matters
   borderRadius: "5px",
   padding: "6px 16px"
 };
@@ -69,11 +74,11 @@ const greenStyle = {
 };
 
 const buttonTypes = {
-  submit: { type: "submit", variant: "contained", color: "primary" },
+  submit: { type: "submit", variant: "contained", color: "primary", style: formDefaultStyle },
   primary: { type: "submit", variant: "contained", style: primaryOverrides },
   manage: { type: "button", variant: "outlined", style: manageStyle },
-  cancel: { type: "button", variant: "outlined", color: "secondary" },
-  default: { type: "button", variant: "contained", color: "primary" },
+  cancel: { type: "button", variant: "outlined", color: "secondary", style: formDefaultOutlinedStyle },
+  default: { type: "button", variant: "contained", color: "primary", style: formDefaultStyle },
   formDefault: { type: "button", variant: "contained", fullWidth: true, style: formDefaultStyle },
   formDefaultOutlined: { type: "button", variant: "outlined", fullWidth: true, style: formDefaultOutlinedStyle },
   remove: { type: "button", variant: "contained", style: remove, size: "large" },


### PR DESCRIPTION
I added `style:` to some of the buttonTypes in Button.js because it was the only way I could get styles to change for `AddUser`.  I'm not at all convinced this is the best way to do this, but am not having any luck getting MaterialUI variants and colors to come through.  

I'm very open to other ways to clean this up.  As it is, there's a lot of repetitive code in the Button component that I can certainly clean up, but I don't want to start changing it all if there's someone with more understanding of how to make MaterialUI play nicely instead of the hacky feeling way I've done it.

As it is, button corners are now rounded and there's padding around buttons again.  There are definitely still some style things with buttons (spacing issues and color checking with figma) that still need to be addressed on a separate PR. 