### PR TITLE
fix 'value' prop warning on checkNumber input field - closes GH #636

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
@@ -55,7 +55,7 @@ export const contributionsEmptyState = {
   amountOfContribution: 0.00,
   submitForMatch: "",
   paymentMethod: "",
-  checkNumber: null,
+  checkNumber: undefined,
 
   // CONTRIBUTOR VALUES
   firstName: "",


### PR DESCRIPTION
This PR fixes the error below that occurs when choosing a `Payment Type` of `Check` on the AddContribution form.  

<img width="1281" alt="Screen Shot 2019-08-13 at 6 54 15 AM" src="https://user-images.githubusercontent.com/6107653/62949391-f3898500-bd9a-11e9-9a83-35474030e3fd.png">
