### PR TITLE
remove columns to allow left justification- closes GH #643

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
@@ -274,8 +274,6 @@ export const ReadyHeaderSection = ({
 export const AddHeaderSection = ({ isValid, handleSubmit }) => (
   <>
     <div css={containers.header}>
-      <div css={headerStyles.leftColumn}></div>
-      <div css={headerStyles.rightColumn}>
         <div style={{ flexDirection: "column" }}>
           <Button
             css={headerStyles.submitButton}
@@ -287,7 +285,6 @@ export const AddHeaderSection = ({ isValid, handleSubmit }) => (
         </Button>
         </div>
       </div>
-    </div>
     <hr css={sectionStyles.dividerLine} />
   </>
 )


### PR DESCRIPTION
Removed unnecessary columns to allow left justification of SAVE AS DRAFT button.

Previously the page looked like:
<img width="1316" alt="Screen Shot 2019-08-13 at 9 27 27 AM" src="https://user-images.githubusercontent.com/6107653/62960709-1bcfae80-bdb0-11e9-81fe-35bd5935e211.png">

Now it should look like this: 
<img width="1317" alt="Screen Shot 2019-08-13 at 9 52 14 AM" src="https://user-images.githubusercontent.com/6107653/62960702-196d5480-bdb0-11e9-9b6f-8a23ec208831.png">

