### PR TITLE
WIP: Changes date from number to string for post body on expenditure/add endpoint

### DIFF
--- a/api/controller/expenditures.ts
+++ b/api/controller/expenditures.ts
@@ -67,8 +67,8 @@ export class AddExpenditureDto implements IAddExpenditureAttrs {
     @IsOptional()
     type: ExpenditureType;
 
-    @IsNumber()
-    date: number;
+    @IsString()
+    date: string;
 }
 
 export async function addExpenditure(request: IRequest, response: Response, next: Function) {

--- a/api/services/expenditureService.ts
+++ b/api/services/expenditureService.ts
@@ -17,7 +17,7 @@ import { createActivityRecordAsync } from './activityService';
 import { User } from '../models/entity/User';
 
 export interface IAddExpenditureAttrs {
-    date: number;
+    date: string;
     type: ExpenditureType;
     subType: ExpenditureSubType;
     payeeType: PayeeType;


### PR DESCRIPTION
Did not look too deeply but this solves the problem. Currently the API requires date to be a number, but it looks like we are using a date string