### PR TITLE
remove labels  from forms - closes GH-657

### DIFF
--- a/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
+++ b/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
@@ -30,7 +30,7 @@ const columns = [
 	columnInfo("Name", "lastName"),
 	columnInfo("Amount", "amount", "currency"),
 	columnInfo("Status", "status"),
-	columnInfo("Labels", "NotSet")
+	// columnInfo("Labels", "NotSet")
 ]
 
 const ContributionsTable = ({ ...props }) => {

--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
@@ -78,15 +78,15 @@ const headerStyles = {
     margin-top: 0px;
     width: 360px;
   `,
-  labelBlock: css`
-    margin-right: 40px;
-  `,
-  labels: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
+  // labelBlock: css`
+  //   margin-right: 40px;
+  // `,
+  // labels: css`
+  //   font-size: 13px;
+  //   line-height: 15px;
+  //   color: #979797;
+  //   margin-bottom: 4px;
+  // `,
   smallBlueText: css`
     font-size: 13px;
     line-height: 15px;
@@ -175,7 +175,7 @@ const sectionStyles = {
 // HEADER VALUES
 const invoiceNumber = "#1030090212"; // TODO: Where is this invoice number coming from/generated? 
 const currentStatus = "Draft";
-const labelsCount = 0;
+// const labelsCount = 0;
 
 const InvoiceNumberBlock = ({ campaignName, lastEdited }) => (
   <>
@@ -193,12 +193,12 @@ const StatusBlock = ({ status }) => (
   </div>
 );
 
-const LabelBlock = ({ labelsCount }) => (
-  <div css={headerStyles.labelBlock}>
-    <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
-    <p css={headerStyles.smallBlueText}>+ Add Labels</p>
-  </div>
-);
+// const LabelBlock = ({ labelsCount }) => (
+//   <div css={headerStyles.labelBlock}>
+//     <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
+//     <p css={headerStyles.smallBlueText}>+ Add Labels</p>
+//   </div>
+// );
 
 // TODO: make a separate component for this checkmark component, find out what it indicates?
 const CheckmarkComponent = ({}) => (
@@ -237,7 +237,7 @@ export const ReadyHeaderSection = ({
   status,
   campaignName,
   lastEdited,
-  labelsCount,
+  // labelsCount,
   isValid,
   handleSubmit,
   handleTrash,
@@ -253,7 +253,6 @@ export const ReadyHeaderSection = ({
             lastEdited={format(new Date(lastEdited), 'MM/DD/YYYY')}
           />
           <div style={{ display: "flex" }}>
-            <LabelBlock labelsCount={labelsCount} />
             <StatusBlock status={status} />
           </div>
         </div>

--- a/app/src/components/Forms/AddExpense/index.js
+++ b/app/src/components/Forms/AddExpense/index.js
@@ -75,15 +75,15 @@ const headerStyles = {
     line-height: 19px;
     margin-top: 0px;
   `,
-  labelBlock: css`
-    margin-right: 40px;
-  `,
-  labels: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
+  // labelBlock: css`
+  //   margin-right: 40px;
+  // `,
+  // labels: css`
+  //   font-size: 13px;
+  //   line-height: 15px;
+  //   color: #979797;
+  //   margin-bottom: 4px;
+  // `,
   smallBlueText: css`
     font-size: 13px;
     line-height: 15px;
@@ -165,7 +165,7 @@ const invoiceNumber = "#1030090212";
 const campaignName = "FakeName";
 const lastEdited = "date";
 const currentStatus = "Draft";
-const labelsCount = 0;
+// const labelsCount = 0;
 
 const invoiceNumberBlock = (
   <React.Fragment>
@@ -184,13 +184,13 @@ const statusBlock = (
   </div>
 );
 
-const labelBlock = (
-  <div css={headerStyles.labelBlock}>
-    <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
-    <p style={{ fontSize: "8px", color: "green" }}>(add icons)</p>
-    <p css={headerStyles.smallBlueText}>Manage</p>
-  </div>
-);
+// const labelBlock = (
+//   <div css={headerStyles.labelBlock}>
+//     <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
+//     <p style={{ fontSize: "8px", color: "green" }}>(add icons)</p>
+//     <p css={headerStyles.smallBlueText}>Manage</p>
+//   </div>
+// );
 
 const AddExpense = () => (
   <AddExpenseForm
@@ -225,7 +225,6 @@ const AddExpense = () => (
           <div css={headerStyles.leftColumn}>
             {invoiceNumberBlock}
             <div style={{ display: "flex" }}>
-              {labelBlock}
               {statusBlock}
             </div>
           </div>

--- a/app/src/components/Forms/CityViews/ContributionNeedsReview/index.js
+++ b/app/src/components/Forms/CityViews/ContributionNeedsReview/index.js
@@ -80,15 +80,15 @@ const headerStyles = {
     margin-top: 0px;
     width: 360px;
   `,
-  labelBlock: css`
-    margin-right: 40px;
-  `,
-  labels: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
+  // labelBlock: css`
+  //   margin-right: 40px;
+  // `,
+  // labels: css`
+  //   font-size: 13px;
+  //   line-height: 15px;
+  //   color: #979797;
+  //   margin-bottom: 4px;
+  // `,
   smallBlueText: css`
     font-size: 13px;
     line-height: 15px;
@@ -181,7 +181,7 @@ const invoiceNumber = "#1030090212";
 const campaignName = "FakeName";
 const lastEdited = "09/09/2019"; // NEEDS TO BE ACTUAL DATE
 const currentStatus = "Needs Review";
-const labelsCount = 0;
+// const labelsCount = 0;
 
 const invoiceNumberBlock = (
   <React.Fragment>
@@ -200,14 +200,14 @@ const statusBlock = (
   </div>
 );
 
-const labelBlock = (
-  <div css={headerStyles.labelBlock}>
-    <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
-    <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
-    {/* placeholder for icon ^ */}
-    <p css={headerStyles.smallBlueText}>Manage</p>
-  </div>
-);
+// const labelBlock = (
+//   <div css={headerStyles.labelBlock}>
+//     <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
+//     <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
+//     {/* placeholder for icon ^ */}
+//     <p css={headerStyles.smallBlueText}>Manage</p>
+//   </div>
+// );
 
 const ContributionNeedsReview = () => (
   <>
@@ -217,7 +217,6 @@ const ContributionNeedsReview = () => (
         <div css={headerStyles.leftColumn}>
           {invoiceNumberBlock}
           <div style={{ display: "flex" }}>
-            {labelBlock}
             {statusBlock}
           </div>
         </div>

--- a/app/src/components/Forms/ContributionSubmitted/index.js
+++ b/app/src/components/Forms/ContributionSubmitted/index.js
@@ -79,15 +79,15 @@ const headerStyles = {
     margin-top: 0px;
     width: 360px;
   `,
-  labelBlock: css`
-    margin-right: 40px;
-  `,
-  labels: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
+  // labelBlock: css`
+  //   margin-right: 40px;
+  // `,
+  // labels: css`
+  //   font-size: 13px;
+  //   line-height: 15px;
+  //   color: #979797;
+  //   margin-bottom: 4px;
+  // `,
   smallBlueText: css`
     font-size: 13px;
     line-height: 15px;
@@ -168,7 +168,7 @@ const invoiceNumber = "#1030090212";
 const campaignName = "FakeName";
 const lastEdited = "09/09/2019"; // NEEDS TO BE ACTUAL DATE
 const currentStatus = "Submitted";
-const labelsCount = 0;
+// const labelsCount = 0;
 
 const invoiceNumberBlock = (
   <React.Fragment>
@@ -187,14 +187,14 @@ const statusBlock = (
   </div>
 );
 
-const labelBlock = (
-  <div css={headerStyles.labelBlock}>
-    <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
-    <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
-    {/* placeholder for icon ^ */}
-    <p css={headerStyles.smallBlueText}>Manage</p>
-  </div>
-);
+// const labelBlock = (
+//   <div css={headerStyles.labelBlock}>
+//     <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
+//     <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
+//     {/* placeholder for icon ^ */}
+//     <p css={headerStyles.smallBlueText}>Manage</p>
+//   </div>
+// );
 
 const ContributionSubmitted = () => (
   <>
@@ -204,7 +204,6 @@ const ContributionSubmitted = () => (
         <div css={headerStyles.leftColumn}>
           {invoiceNumberBlock}
           <div style={{ display: "flex" }}>
-            {labelBlock}
             {statusBlock}
           </div>
         </div>

--- a/app/src/components/Forms/ExpensesDetail/index.js
+++ b/app/src/components/Forms/ExpensesDetail/index.js
@@ -79,15 +79,15 @@ const headerStyles = {
     margin-top: 0px;
     width: 360px;
   `,
-  labelBlock: css`
-    margin-right: 40px;
-  `,
-  labels: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
+  // labelBlock: css`
+  //   margin-right: 40px;
+  // `,
+  // labels: css`
+  //   font-size: 13px;
+  //   line-height: 15px;
+  //   color: #979797;
+  //   margin-bottom: 4px;
+  // `,
   smallBlueText: css`
     font-size: 13px;
     line-height: 15px;
@@ -168,7 +168,7 @@ const invoiceNumber = "#1030090212";
 const campaignName = "FakeName";
 const lastEdited = "09/09/2019"; // NEEDS TO BE ACTUAL DATE
 const currentStatus = "Submitted";
-const labelsCount = 0;
+// const labelsCount = 0;
 
 const invoiceNumberBlock = (
   <React.Fragment>
@@ -187,14 +187,14 @@ const statusBlock = (
   </div>
 );
 
-const labelBlock = (
-  <div css={headerStyles.labelBlock}>
-    <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
-    <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
-    {/* placeholder for icon ^ */}
-    <p css={headerStyles.smallBlueText}>Manage</p>
-  </div>
-);
+// const labelBlock = (
+//   <div css={headerStyles.labelBlock}>
+//     <p css={headerStyles.labels}>{`Labels (${labelsCount})`}</p>
+//     <p style={{ fontSize: "7px", color: "green" }}>()()()</p>
+//     {/* placeholder for icon ^ */}
+//     <p css={headerStyles.smallBlueText}>Manage</p>
+//   </div>
+// );
 
 const ExpensesDetail = () => (
   <>
@@ -204,7 +204,6 @@ const ExpensesDetail = () => (
         <div css={headerStyles.leftColumn}>
           {invoiceNumberBlock}
           <div style={{ display: "flex" }}>
-            {labelBlock}
             {statusBlock}
           </div>
         </div>


### PR DESCRIPTION
This PR prevents `label` sections from displaying on forms, including contributions and expenses forms and tables

    - removed from displaying on table header and form sections
    - removed from displaying on both AddExpense and Contributions

My understanding is we may use these fields in the future, so I've commented them out rather than deleting them completely.  Let me know if I should go ahead and delete them.