### PR TITLE
#670 Return not in portland if missing lat or long

### DIFF
--- a/datascience/openelections/api/donor_lookup.py
+++ b/datascience/openelections/api/donor_lookup.py
@@ -39,8 +39,8 @@ class DonorMatch(Resource):
             aparser.add_argument("addr1", type=str, required=True)
             aparser.add_argument("addr2", default=None, type=str)
             aparser.add_argument("city", default=None, type=str)
-            aparser.add_argument("latitude", dest="latitude", type=str)
-            aparser.add_argument("longitude", dest="longitude", type=str)
+            aparser.add_argument("latitude", dest="latitude", default=None, type=str)
+            aparser.add_argument("longitude", dest="longitude", default=None, type=str)
             aparser.add_argument("max_matches", default=10, type=int)
 
             options = aparser.parse_args()

--- a/datascience/openelections/donor_lookup/match.py
+++ b/datascience/openelections/donor_lookup/match.py
@@ -60,7 +60,7 @@ def tokenize_address(addr1: str, addr2: Optional[str] = None) -> Set[str]:
     return set(ADDRESS_MAP.get(tkn, tkn) for tkn in address_tokens if tkn != '') - ADDRESS_IGNORE
 
 
-def in_portland(longitude: str, latitude: str) -> bool:
+def in_portland(longitude: Optional[str], latitude: Optional[str]) -> bool:
     """
     Returns true if lat/long are within city limits
     NB PostGIS places longitude first!
@@ -68,6 +68,9 @@ def in_portland(longitude: str, latitude: str) -> bool:
     :param zip_code:
     :return:
     """
+
+    if longitude is None or latitude is None:
+        return False
 
     with psycopg2.connect(**db.POSTGRES_LOGIN) as conn:
         with conn.cursor() as curr:
@@ -252,8 +255,8 @@ def cli() -> None:
         aparser.add_argument("--addr1", dest="addr1", type=str)
         aparser.add_argument("--addr2", dest="addr2", default=None, type=str)
         aparser.add_argument("--city", dest="city", default=None, type=str)
-        aparser.add_argument("--latitude", dest="latitude", type=str)
-        aparser.add_argument("--longitude", dest="longitude", type=str)
+        aparser.add_argument("--latitude", dest="latitude", default=None, type=str)
+        aparser.add_argument("--longitude", dest="longitude", default=None, type=str)
         aparser.add_argument("--max_matches", dest="max_matches", default=10, type=int)
 
         options = vars(aparser.parse_args())

--- a/datascience/tests/donor_lookup/test_match.py
+++ b/datascience/tests/donor_lookup/test_match.py
@@ -221,9 +221,18 @@ class TestInPortland():
         Ensure that wrong zip code returns false
         :return:
         """
-        test_data = [('t')]
+        test_data = [(False,)]
         setup_mock_connect(mock_connect=mock_connect, test_data=test_data)
 
         from openelections.donor_lookup.match import in_portland
 
         assert not in_portland(latitude='45.51179', longitude='-122.67563')
+
+    def test_missing_lat_log(self):
+        """
+        Ensure that wrong zip code returns false
+        :return:
+        """
+        from openelections.donor_lookup.match import in_portland
+
+        assert not in_portland(latitude=None, longitude=None)


### PR DESCRIPTION
* Modified in_portland check to return false when missing lat/long
* Modified a test which was failing