### PR TITLE
Disallow negative - closes gh 681

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
@@ -143,13 +143,13 @@ export const fields = {
     'A contributor type is required',
     individualContributorValues.concat(entityContributorValues)
   ),
-  amountOfContribution: requiredFormField(
-    'Amount of Contribution',
-    FormSectionEnum.BASIC,
-    CurrencyField,
-    Yup.number('Choose the amount of contribution'),
-    'The contribution amount is required'
-  ),
+  amountOfContribution: {
+    label: 'Amount of Contribution',
+    section: FormSectionEnum.BASIC,
+    component: CurrencyField,
+    options: { allowNegative: false },
+    validation: Yup.number('Choose the amount of contribution'),
+  },
   oaeType: requiredFormField(
     'OAE Contribution Type',
     FormSectionEnum.BASIC,

--- a/app/src/components/Fields/CurrencyField.js
+++ b/app/src/components/Fields/CurrencyField.js
@@ -20,7 +20,6 @@ function NumberFormatCustom(props) {
       thousandSeparator
       prefix="$"
       decimalScale="2"
-      allowNegative={false}
     />
   );
 }
@@ -30,7 +29,7 @@ NumberFormatCustom.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-export default function CurrencyField({ id, label, formik }) {
+export default function CurrencyField({ id, label, formik, options }) {
   return (
     <TextFieldMaterial
       id={id}
@@ -45,6 +44,7 @@ export default function CurrencyField({ id, label, formik }) {
       fullWidth
       InputProps={{
         inputComponent: NumberFormatCustom,
+        inputProps: { allowNegative: options.allowNegative },
       }}
     />
   );

--- a/app/src/components/Fields/CurrencyField.js
+++ b/app/src/components/Fields/CurrencyField.js
@@ -20,6 +20,7 @@ function NumberFormatCustom(props) {
       thousandSeparator
       prefix="$"
       decimalScale="2"
+      allowNegative={false}
     />
   );
 }


### PR DESCRIPTION
Closes GH #681

Please check that as a user you can't enter a negative contribution amount.  

Also, please test that if the options are changed in `ContributionFields.js` to `allowNegative: true`, a user _should_ be able to add a negative amount. 
<img width="930" alt="Screen Shot 2019-08-20 at 1 57 32 PM" src="https://user-images.githubusercontent.com/6107653/63384033-dfbdc000-c352-11e9-99df-7f51ac0312bd.png">
