### PR TITLE
update logic for error on purposeType

### DIFF
--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -402,7 +402,7 @@ export const validate = values => {
 
   // Default to visible
   visible.paymentMethod = true;
-  visible.purposeType = true;
+  visible.showPurposeType = false;
 
   // LOGIC FOR FOR FIELDS THAT ARE REQUIRED ONLY CONDITIONALLY:
   if (visible.checkSelected && isEmpty(checkNumber)) {
@@ -412,18 +412,21 @@ export const validate = values => {
         : 'Money Order number is required.';
   }
 
-  // PurposeType only required if Miscellaneous Other Disbursement is selected for Sub Type.
+  // PurposeType only visble & required if Miscellaneous Other Disbursement is selected for Sub Type.
   visible.showPurposeType = !!(
     expenditureSubType ===
     ExpenditureSubTypeEnum.MISCELLANEOUS_OTHER_DISBURSEMENT
   );
 
   if (visible.showPurposeType) {
-    visible.purposeType = false;
-    if (isEmpty(purposeType))
+    if (isEmpty(values.purposeType)) {
       error.purposeType = 'A description of type of purpose is required';
+    }
   }
 
   values._visibleIf = visible;
+  console.log('error; ', error);
+  console.log('visible.purposeType', visible.purposeType);
+  console.log('visible.showPurposeType: ', visible.showPurposeType);
   return error;
 };

--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -256,7 +256,7 @@ export const fields = {
     label: 'Purpose of Expenditure',
     section: FormSectionEnum.BASIC,
     component: SelectField,
-    validation: Yup.string(),
+    validation: Yup.string().nullable(),
     options: {
       values: [
         { value: PurposeTypeEnum.WAGES, label: 'Wages' },

--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -278,10 +278,7 @@ export const fields = {
         { value: PurposeTypeEnum.UTILITIES, label: 'Utilities' },
       ],
     },
-    validation: Yup.string().required(
-      'A description of the purpose is required'
-    ),
-    // purposeType IS REQUIRED IF: Miscellaneous Other Disbursement is selected for Sub Type.
+    validation: Yup.string(),
   },
 
   // PAYEE SECTION
@@ -375,7 +372,7 @@ export const validate = values => {
     expenditureSubType,
     paymentMethod,
     checkNumber,
-    // purposeType,
+    purposeType,
 
     // // PAYEE INFO
     payeeType,
@@ -405,7 +402,7 @@ export const validate = values => {
 
   // Default to visible
   visible.paymentMethod = true;
-  visible.showPurposeType = true;
+  visible.purposeType = true;
 
   // LOGIC FOR FOR FIELDS THAT ARE REQUIRED ONLY CONDITIONALLY:
   if (visible.checkSelected && isEmpty(checkNumber)) {
@@ -420,6 +417,12 @@ export const validate = values => {
     expenditureSubType ===
     ExpenditureSubTypeEnum.MISCELLANEOUS_OTHER_DISBURSEMENT
   );
+
+  if (visible.showPurposeType) {
+    visible.purposeType = false;
+    if (isEmpty(purposeType))
+      error.purposeType = 'A description of type of purpose is required';
+  }
 
   values._visibleIf = visible;
   return error;

--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -52,18 +52,18 @@ export const mapExpenditureDataToForm = expenditure => {
     buttonSubmitted: buttonSubmitted || '',
     amount: amount || '',
     date: format(new Date(date), 'YYYY-MM-DD'),
-    expenditureType: type || '',
+    expenditureType: type,
     expenditureSubType: subType,
-    paymentMethod: paymentMethod || '',
+    paymentMethod,
     checkNumber: checkNumber || '',
-    purposeType: purpose || '',
-    payeeType: payeeType || '',
-    payeeName: name || '',
-    streetAddress: address1 || '',
+    purposeType: purpose || null,
+    payeeType,
+    payeeName: name,
+    streetAddress: address1,
     addressLine2: address2 || '',
-    city: city || '',
-    state: state || '',
-    zipcode: zip || '',
+    city,
+    state,
+    zipcode: zip,
     notes: notes || '',
     status,
     updatedAt: format(new Date(updatedAt), 'MM-DD-YY hh:mm a'),
@@ -102,7 +102,7 @@ export const mapExpenditureFormToData = data => {
     subType: expenditureSubType,
     checkNumber,
     paymentMethod,
-    purpose: purposeType,
+    purpose: purposeType || null,
     payeeType,
     name: payeeName,
     address1: streetAddress,
@@ -278,7 +278,7 @@ export const fields = {
         { value: PurposeTypeEnum.UTILITIES, label: 'Utilities' },
       ],
     },
-    validation: Yup.string(),
+    // validation: Yup.string(),
   },
 
   // PAYEE SECTION
@@ -372,7 +372,7 @@ export const validate = values => {
     expenditureSubType,
     paymentMethod,
     checkNumber,
-    purposeType,
+    // purposeType,
 
     // // PAYEE INFO
     payeeType,
@@ -388,11 +388,6 @@ export const validate = values => {
   const visible = {};
 
   // LOGIC FOR CONDITIONALLY VISIBLE FIELDS OR DROPDOWN SELECT OPTIONS:
-
-  // Make these areas visible
-  visible.isPerson = !!(
-    payeeType === PayeeTypeEnum.INDIVIDUAL || payeeType === PayeeTypeEnum.FAMILY
-  );
 
   // If PaymentMethod was check, show check number field
   visible.checkSelected = !!(
@@ -419,7 +414,7 @@ export const validate = values => {
   );
 
   if (visible.showPurposeType) {
-    if (isEmpty(values.purposeType)) {
+    if (values.purposeType && values.purposeType === '') {
       error.purposeType = 'A description of type of purpose is required';
     }
   }

--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -118,6 +118,7 @@ export const mapExpenditureFormToData = data => {
 
 export const expendituresEmptyState = {
   // BASICS VALUES
+  id: '',
   amount: '',
   date: '',
   expenditureType: '',
@@ -132,7 +133,7 @@ export const expendituresEmptyState = {
   streetAddress: '',
   addressLine2: '',
   city: '',
-  state: '',
+  state: 'OR',
   zipcode: '',
   notes: '',
 };
@@ -255,6 +256,7 @@ export const fields = {
     label: 'Purpose of Expenditure',
     section: FormSectionEnum.BASIC,
     component: SelectField,
+    validation: Yup.string(),
     options: {
       values: [
         { value: PurposeTypeEnum.WAGES, label: 'Wages' },
@@ -278,7 +280,6 @@ export const fields = {
         { value: PurposeTypeEnum.UTILITIES, label: 'Utilities' },
       ],
     },
-    // validation: Yup.string(),
   },
 
   // PAYEE SECTION
@@ -366,16 +367,13 @@ export const fields = {
 
 export const validate = values => {
   const {
-    // amount,
-    // dateOfExpenditure,
-    // expenditureType,
     expenditureSubType,
     paymentMethod,
     checkNumber,
-    // purposeType,
+    purposeType,
 
     // // PAYEE INFO
-    payeeType,
+    // payeeType,
     // payeeName,
     // streetAddress,
     // addressLine2,
@@ -414,14 +412,14 @@ export const validate = values => {
   );
 
   if (visible.showPurposeType) {
-    if (values.purposeType && values.purposeType === '') {
+    if (isEmpty(purposeType)) {
       error.purposeType = 'A description of type of purpose is required';
     }
   }
 
   values._visibleIf = visible;
   console.log('error; ', error);
-  console.log('visible.purposeType', visible.purposeType);
+  console.log('values.purposeType', values.purposeType);
   console.log('visible.showPurposeType: ', visible.showPurposeType);
   return error;
 };

--- a/app/src/Pages/Portal/Expenses/ExpendituresFields.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresFields.js
@@ -371,16 +371,6 @@ export const validate = values => {
     paymentMethod,
     checkNumber,
     purposeType,
-
-    // // PAYEE INFO
-    // payeeType,
-    // payeeName,
-    // streetAddress,
-    // addressLine2,
-    // city,
-    // state,
-    // zipcode,
-    // notes,
   } = values;
   const error = {};
   const visible = {};
@@ -411,15 +401,10 @@ export const validate = values => {
     ExpenditureSubTypeEnum.MISCELLANEOUS_OTHER_DISBURSEMENT
   );
 
-  if (visible.showPurposeType) {
-    if (isEmpty(purposeType)) {
-      error.purposeType = 'A description of type of purpose is required';
-    }
+  if (visible.showPurposeType && isEmpty(purposeType)) {
+    error.purposeType = 'A description of type of purpose is required';
   }
 
   values._visibleIf = visible;
-  console.log('error; ', error);
-  console.log('values.purposeType', values.purposeType);
-  console.log('visible.showPurposeType: ', visible.showPurposeType);
   return error;
 };

--- a/app/src/components/Forms/AddExpense/index.js
+++ b/app/src/components/Forms/AddExpense/index.js
@@ -40,8 +40,9 @@ const AddExpense = ({ ...props }) => (
     onSubmit={data => onSubmit(data, props)}
     initialValues={expendituresEmptyState}
   >
-    {({ formFields, isValid, handleSubmit, visibleIf, formErrors }) => {
-      console.log('Required fields', Object.keys(formErrors));
+    {({ formFields, isValid, handleSubmit, visibleIf }) => {
+      // uncomment line below & pass formErrors to line above to see required fields
+      // console.log('Required fields', Object.keys(formErrors));
       return (
         <>
           <AddHeaderSection isValid={isValid} handleSubmit={handleSubmit} />

--- a/app/src/components/Forms/ExpensesDetail/index.js
+++ b/app/src/components/Forms/ExpensesDetail/index.js
@@ -124,6 +124,7 @@ class ExpensesDetailForm extends React.Component {
                 checkSelected={visibleIf.checkSelected}
                 showInKindFields={visibleIf.showInKindFields}
                 showPaymentMethod={visibleIf.paymentMethod}
+                showPurposeType={visibleIf.showPurposeType}
               />
               <PayeeInfoSection
                 isSubmited={isSubmited}


### PR DESCRIPTION
I'd love some help finishing this out...

This works if I choose the specific criteria my method is for ( ExpenditureType of “Other Disbursement” and ExpenditureSubType of “Miscellaneous Other Disbursement”). However, the form won’t submit if anything else is selected.

I can get it to work if I hardcode the initial value of purposeType as one of the enum choices. Then I can do any kind of expenditure and it will go through.  This confirms for me that the form is still always wanting a value for purposeType regardless of my current logic.

So, does purposeType need to be some version of…
   ``` @Column({
        type: 'enum',
        enum: PurposeType,
        nullable: true
    })
    purpose?: PurposeType; 
```

Does the backend need to be set to allow null and not be required?