### PR TITLE
Show campaign name on expenditure and contribution forms

### DIFF
--- a/app/src/components/Forms/ContributionReady/index.js
+++ b/app/src/components/Forms/ContributionReady/index.js
@@ -6,11 +6,11 @@ import { flashMessage } from 'redux-flash';
 import { updateContribution } from '../../../state/ducks/contributions';
 import {
   getCurrentUserId,
+  getCurrentCampaignName,
   isGovAdmin,
   isCampAdmin,
   isCampStaff,
 } from '../../../state/ducks/auth';
-import { getCampaignName } from '../../../state/ducks/campaigns';
 import {
   AddHeaderSection,
   ViewHeaderSection,
@@ -161,7 +161,7 @@ export default connect(
     isGovAdmin: isGovAdmin(state),
     isCampAdmin: isCampAdmin(state),
     isCampStaff: isCampStaff(state),
-    campaignName: getCampaignName(state),
+    campaignName: getCurrentCampaignName(state),
   }),
   dispatch => ({
     flashMessage: (message, options) =>

--- a/app/src/components/Forms/ExpensesDetail/index.js
+++ b/app/src/components/Forms/ExpensesDetail/index.js
@@ -6,6 +6,7 @@ import { flashMessage } from 'redux-flash';
 import { updateExpenditure } from '../../../state/ducks/expenditures';
 import {
   getCurrentUserId,
+  getCurrentCampaignName,
   isGovAdmin,
   isCampAdmin,
   isCampStaff,
@@ -17,7 +18,6 @@ import {
 } from '../../../Pages/Portal/Expenses/ExpendituresSections';
 import AddExpenseForm from '../AddExpense/AddExpenseForm';
 import { ExpenditureStatusEnum } from '../../../api/api';
-import { getCampaignName } from '../../../state/ducks/campaigns';
 import { mapExpenditureFormToData } from '../../../Pages/Portal/Expenses/ExpendituresFields';
 
 const onSubmit = (data, props) => {
@@ -144,7 +144,7 @@ export default connect(
     isGovAdmin: isGovAdmin(state),
     isCampAdmin: isCampAdmin(state),
     isCampStaff: isCampStaff(state),
-    campaignName: getCampaignName(state),
+    campaignName: getCurrentCampaignName(state),
   }),
   dispatch => ({
     flashMessage: (message, options) =>

--- a/app/src/components/Sidebar/index.js
+++ b/app/src/components/Sidebar/index.js
@@ -1,12 +1,15 @@
 import { connect } from 'react-redux';
 import Sidebar from './Sidebar';
-import { getCampaignName } from '../../state/ducks/campaigns';
-import { isGovAdmin, getCurrentCampaignId } from '../../state/ducks/auth';
+import {
+  getCurrentCampaignName,
+  isGovAdmin,
+  getCurrentCampaignId,
+} from '../../state/ducks/auth';
 import { getCampaignUsers } from '../../state/ducks/users';
 
 export default connect(
   state => ({
-    campaignName: getCampaignName(state),
+    campaignName: getCurrentCampaignName(state),
     isGovAdmin: isGovAdmin(state),
     campaignId: getCurrentCampaignId(state),
   }),

--- a/app/src/state/ducks/auth.js
+++ b/app/src/state/ducks/auth.js
@@ -382,3 +382,14 @@ export const getCurrentCampaignId = state => {
   }
   return null;
 };
+
+export const getCurrentCampaignName = state => {
+  if (state.auth.me) {
+    if (
+      state.auth.me.permissions[0] &&
+      state.auth.me.permissions[0].campaignName
+    )
+      return state.auth.me.permissions[0].campaignName;
+  }
+  return 'Campaign';
+};


### PR DESCRIPTION
Uses current users permissions to pull campaign name.