### PR TITLE
make archive button only show if draft/submitted as campaign - closes #608

### DIFF
--- a/app/src/Pages/Portal/Expenses/ExpendituresSections.js
+++ b/app/src/Pages/Portal/Expenses/ExpendituresSections.js
@@ -3,164 +3,13 @@ import React from 'react';
 import { css, jsx } from '@emotion/core';
 import { ExpenditureStatusEnum } from '../../../api/api';
 import Button from '../../../components/Button/Button';
+import {
+  containers,
+  headerStyles,
+  sectionStyles,
+  buttonBar,
+} from '../../../assets/styles/forms.styles';
 
-const containers = {
-  header: css`
-    width: 96%%;
-    min-height: 100%;
-    display: grid;
-    grid-template-rows: repeat(auto-fit(15px, 1fr));
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    grid-gap: 20px;
-  `,
-  main: css`
-    display: grid;
-    grid-template-rows: repeat(auto-fit(50px, 1fr));
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    grid-gap: 20px;
-    margin-bottom: 20px;
-  `,
-  sectionTwo: css`
-    display: grid;
-    grid-template-rows: repeat(auto-fit(50px, 1fr));
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    grid-gap: 20px;
-    margin-bottom: 20px;
-  `,
-  fullWidth: css`
-    display: grid;
-    grid-template-rows: repeat(auto-fit(50px, 1fr));
-    grid-template-columns: 1fr;
-    grid-gap: 20px;
-    margin-bottom: 20px;
-  `,
-  cityStateZip: css`
-    width: 96%%;
-    min-height: 25px;
-    display: grid;
-    grid-template-rows: repeat(auto-fit, minmax(15px, 1fr));
-    grid-template-columns: 2fr 22% 24%;
-    grid-gap: 20px;
-    margin-bottom: 20px;
-  `,
-};
-
-const headerStyles = {
-  header: css`
-    display: flex;
-    justify-content: space-between;
-    margin-right: 38px;
-    font-family: Rubik;
-    font-style: normal;
-    font-weight: normal;
-  `,
-  leftColumn: css`
-    margin-right: 70px;
-  `,
-  rightColumn: css`
-    display: flex;
-    align-items: flex-end;
-  `,
-  invoice: css`
-    font-size: 48px;
-    line-height: 57px;
-    margin: 0px;
-    /* identical to box height */
-    color: #333333;
-  `,
-  subheading: css`
-    font-size: 16px;
-    line-height: 19px;
-    margin-top: 0px;
-  `,
-  smallBlueText: css`
-    font-size: 13px;
-    line-height: 15px;
-    margin: 0px;
-    /* Link */
-    color: #5f5fff;
-  `,
-  largerBlueText: css`
-    font-size: 16px;
-    line-height: 19px;
-    margin: 0px;
-    /* Link */
-    color: #5f5fff;
-  `,
-  status: css`
-    font-size: 13px;
-    line-height: 15px;
-    color: #979797;
-    margin-bottom: 4px;
-  `,
-  actualStatus: css`
-    font-size: 21px;
-    line-height: 25px;
-    color: #000000;
-    margin-top: 0px;
-    margin: 0px;
-  `,
-  statusBlock: css`
-    flex-direction: column;
-    align-items: left;
-  `,
-  buttonDiv: css`
-    display: flex;
-    justify-content: space-between;
-    align-self: flex-end;
-  `,
-  submitButton: css`
-    background-color: #d8d8d8;
-    border-radius: 5px;
-    color: white;
-    width: 165px;
-    height: 50px;
-  `,
-  draftButton: css`
-    // HAVING ZERO IMPACT
-    background-color: #5f5fff;
-    border-radius: 5px;
-    width: 165px;
-    height: 50px;
-  `,
-};
-
-const sectionStyles = {
-  main: css`
-    margin-right: 34px;
-    margin-bottom: 34px;
-    margin-top: 34px;
-  `,
-  dividerLine: css`
-    margin-left: -20px;
-  `,
-  title: css`
-    font-family: Rubik;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 24px;
-    line-height: 28px;
-    width: 100%;
-    color: #000000;
-    margin-top: 55px;
-  `,
-  notes: css`
-    margin-top: 75px;
-  `,
-};
-const buttonBar = {
-  wrapper: css`
-    position: relative;
-  `,
-  container: css`
-    position: absolute;
-    right: 0;
-    bottom: 0;
-  `,
-  button: css`
-    margin: 1px;
-  `,
-};
 export const ViewHeaderSection = ({
   isValid,
   handleSubmit,
@@ -238,6 +87,20 @@ export const ViewHeaderSection = ({
               }}
             >
               Move to Draft
+            </Button>
+          ) : null}
+          {status === ExpenditureStatusEnum.SUBMITTED &&
+          (isCampStaff || isCampAdmin) ? (
+            <Button
+              css={headerStyles.submitButton}
+              style={{ margin: 1 }}
+              buttonType="submit"
+              onClick={() => {
+                formValues.buttonSubmitted = 'archive';
+                handleSubmit();
+              }}
+            >
+              Archive
             </Button>
           ) : null}
         </div>


### PR DESCRIPTION
As a campaign admin or staff the archive button should appear when the status is `draft` or `submitted` and it should not appear for gov.  I tested this and it's behaving the same as for Contributions.

Aside- I also took out the css so it's using the shared form styles.