### PR TITLE
Adds redirect for 401 on me duct

### DIFF
--- a/app/__snapshots__/Pages/Portal/Dashboard/Dashboard.test.js.snap
+++ b/app/__snapshots__/Pages/Portal/Dashboard/Dashboard.test.js.snap
@@ -75,8 +75,43 @@ exports[`<Dashboard/> should be defined 1`] = `
       >
         <div
           className="card small"
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
         >
           <SearchCard />
+          <EmotionCssPropInternal
+            __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DashboardPage"
+            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+            css={
+              Object {
+                "map": undefined,
+                "name": "n6rjmm",
+                "next": undefined,
+                "styles": "
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(240, 240, 240, 0.8);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  &:before {
+    content: 'Coming Soon ...';
+    font-size: 20px;
+    color: #888;
+    margin-bottom: 20px;
+  }
+",
+              }
+            }
+          />
         </div>
         <div
           className="card small"

--- a/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
+++ b/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
@@ -21,6 +21,7 @@ import {
   isCampAdmin,
   isGovAdmin,
   isLoggedIn,
+  getCurrentUserId,
 } from '../../../../state/ducks/auth';
 import { mediaQueryRanges } from '../../../../assets/styles/variables';
 
@@ -303,7 +304,7 @@ export default connect(
       state.governments.currentGovernmentId,
     campaignId: state.campaigns.currentCampaignId,
     govId: state.governments.currentGovernmentId || 1,
-    userId: isLoggedIn(state) ? state.auth.me.id : null,
+    userId: getCurrentUserId(state),
     total: state.contributions.total,
   }),
   dispatch => {

--- a/app/src/state/ducks/auth.js
+++ b/app/src/state/ducks/auth.js
@@ -338,6 +338,14 @@ export function redirectToLogin() {
   };
 }
 
+export function checkForUnauthorizedResponse(response) {
+  return dispatch => {
+    if (response.status === 401 || response.status === 422) {
+      dispatch(logout());
+    }
+  };
+}
+
 // Selectors
 export const rootState = state => state || {};
 

--- a/app/src/state/ducks/contributions.js
+++ b/app/src/state/ducks/contributions.js
@@ -13,6 +13,7 @@ import {
   RESET_STATE,
 } from './common';
 import { getContributionActivities } from './activities';
+import { checkForUnauthorizedResponse } from './auth';
 
 export const STATE_KEY = 'contributions';
 
@@ -220,7 +221,7 @@ export function getContributions(contributionSearchAttrs) {
     dispatch(actionCreators.getContributions.request());
     try {
       const response = await api.getContributions(contributionSearchAttrs);
-
+      dispatch(checkForUnauthorizedResponse(response));
       if (response.status === 200) {
         const contributions = await response.json();
         const data = normalize(contributions.data, [schema.contribution]);

--- a/app/src/state/ducks/contributions.js
+++ b/app/src/state/ducks/contributions.js
@@ -13,7 +13,6 @@ import {
   RESET_STATE,
 } from './common';
 import { getContributionActivities } from './activities';
-import { checkForUnauthorizedResponse } from './auth';
 
 export const STATE_KEY = 'contributions';
 
@@ -221,7 +220,6 @@ export function getContributions(contributionSearchAttrs) {
     dispatch(actionCreators.getContributions.request());
     try {
       const response = await api.getContributions(contributionSearchAttrs);
-      dispatch(checkForUnauthorizedResponse(response));
       if (response.status === 200) {
         const contributions = await response.json();
         const data = normalize(contributions.data, [schema.contribution]);


### PR DESCRIPTION
Checks for returned  {"message":"Token expired or incorrect"} on ME. Forces login when cookie is stale and browser is refreshed.

Adds a method for checking return status of other thunks, checkForUnauthorizedResponse(). This function test for 401 and forces login without refresh. Did not implement, added issue #798 to implement.