### PR TITLE
make flash messages mimic contribution flash messages- closes #800

### DIFF
--- a/app/__snapshots__/Pages/Portal/Dashboard/Dashboard.test.js.snap
+++ b/app/__snapshots__/Pages/Portal/Dashboard/Dashboard.test.js.snap
@@ -75,8 +75,43 @@ exports[`<Dashboard/> should be defined 1`] = `
       >
         <div
           className="card small"
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
         >
           <SearchCard />
+          <EmotionCssPropInternal
+            __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DashboardPage"
+            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+            css={
+              Object {
+                "map": undefined,
+                "name": "n6rjmm",
+                "next": undefined,
+                "styles": "
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(240, 240, 240, 0.8);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  &:before {
+    content: 'Coming Soon ...';
+    font-size: 20px;
+    color: #888;
+    margin-bottom: 20px;
+  }
+",
+              }
+            }
+          />
         </div>
         <div
           className="card small"

--- a/app/src/state/ducks/expenditures.js
+++ b/app/src/state/ducks/expenditures.js
@@ -119,7 +119,7 @@ export function createExpenditure(expenditureAttrs) {
         dispatch(addExpenditureEntities(data.entities));
         dispatch(actionCreators.createExpenditure.success());
         dispatch(
-          flashMessage(`Contribution Added`, {
+          flashMessage(`Expenditure Added`, {
             props: { variant: 'success' },
           })
         );
@@ -146,12 +146,30 @@ export function updateExpenditure(expenditureAttrs) {
     try {
       const response = await api.updateExpenditure(expenditureAttrs);
       if (response.status === 204) {
+        let status = '';
+        if (expenditureAttrs.status) {
+          status = expenditureAttrs.status;
+        }
         dispatch(actionCreators.updateExpenditure.success());
+        dispatch(
+          flashMessage(`Expenditure Updated ${status}`, {
+            props: { variant: 'success' },
+          })
+        );
       } else {
         dispatch(actionCreators.updateExpenditure.failure());
+        const error = await response.json();
+        dispatch(
+          flashMessage(`Error - ${error}`, { props: { variant: 'error' } })
+        );
+        return error;
       }
     } catch (error) {
       dispatch(actionCreators.updateExpenditure.failure(error));
+      dispatch(
+        flashMessage(`Error - ${error}`, { props: { variant: 'error' } })
+      );
+      return error;
     }
   };
 }


### PR DESCRIPTION
Should show appropriate messages in response to users changing status of expenditure.  
eg-
<img width="662" alt="Screen Shot 2019-09-10 at 1 22 52 PM" src="https://user-images.githubusercontent.com/6107653/64647623-30628f00-d3ce-11e9-8b55-972830612170.png">
