### PR TITLE
Fix: keep data order as it comes from the server

### DIFF
--- a/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
+++ b/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
@@ -79,12 +79,7 @@ const columns = isGovAdmin => {
 };
 
 const ContributionsTable = ({ ...props }) => {
-  const [sortFilter, setSortFilter] = useState({
-    sort: {
-      field: 'date',
-      direction: 'DESC',
-    },
-  });
+  const [sortFilter, setSortFilter] = useState({});
   const [filterOptions, setFilterOptions] = useState({});
   const [paginationOptions, setPaginationOptions] = useState({
     perPage: 50,

--- a/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
+++ b/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
@@ -66,12 +66,7 @@ const columns = isGovAdmin => [
 ];
 
 const ExpensesTable = ({ ...props }) => {
-  const [sortFilter, setSortFilter] = useState({
-    sort: {
-      field: 'date',
-      direction: 'DESC',
-    },
-  });
+  const [sortFilter, setSortFilter] = useState({});
   const [filterOptions, setFilterOptions] = useState({});
   const [paginationOptions, setPaginationOptions] = useState({
     perPage: 50,

--- a/app/src/state/ducks/contributions.js
+++ b/app/src/state/ducks/contributions.js
@@ -222,9 +222,10 @@ export function getContributions(contributionSearchAttrs) {
       const response = await api.getContributions(contributionSearchAttrs);
       if (response.status === 200) {
         const contributions = await response.json();
-        const data = normalize(contributions.data, [schema.contribution]);
-
-        dispatch(addContributionEntities(data.entities));
+        // const data = normalize(contributions.data, [schema.contribution]);
+        dispatch(
+          addContributionEntities({ contributions: contributions.data })
+        );
         dispatch(actionCreators.getContributions.success(contributions.total));
       } else {
         dispatch(actionCreators.getContributions.failure());

--- a/app/src/state/ducks/expenditures.js
+++ b/app/src/state/ducks/expenditures.js
@@ -182,7 +182,7 @@ export function getExpenditures(expenditureSearchAttrs) {
       if (response.status === 200) {
         const expenses = await response.json();
         const data = normalize(expenses.data, [schema.expenditure]);
-        dispatch(addExpenditureEntities(data.entities));
+        dispatch(addExpenditureEntities({ expenditures: expenses.data }));
         dispatch(actionCreators.getExpenditures.success(expenses.total));
       } else {
         dispatch(actionCreators.getExpenditures.failure());


### PR DESCRIPTION
👉by eliminating normalize()

We thought it was a server bug, but apparently the normalize function messes up the order of the data coming from the server