### PR TITLE
Persist order of returned lists 

### DIFF
--- a/app/src/state/ducks/contributions.js
+++ b/app/src/state/ducks/contributions.js
@@ -312,7 +312,6 @@ export const getContributionsList = createSelector(
     return state.contributions.listOrder.map(
       id => state.contributions.list[id]
     );
-    // return Object.values(state.contributions.list);
   }
 );
 

--- a/app/src/state/ducks/contributions.js
+++ b/app/src/state/ducks/contributions.js
@@ -36,6 +36,7 @@ export const actionTypes = {
 // Initial State
 export const initialState = {
   list: null,
+  listOrder: [],
   isLoading: false,
   error: null,
   currentId: 0,
@@ -49,7 +50,11 @@ export default createReducer(initialState, {
     return { ...initialState };
   },
   [ADD_CONTRIBUTION_ENTITIES]: (state, action) => {
-    return { ...state, list: { ...action.payload.contributions } };
+    return {
+      ...state,
+      list: { ...action.payload.entities.contributions },
+      listOrder: action.payload.result,
+    };
   },
   [actionTypes.CREATE_CONTRIBUTION.REQUEST]: (state, action) => {
     return { ...state, isLoading: true };
@@ -158,7 +163,7 @@ export function createContribution(contributionAttrs) {
       const response = await api.createContribution(contributionAttrs);
       if (response.status === 201) {
         const data = normalize(await response.json(), schema.contribution);
-        dispatch(addContributionEntities(data.entities));
+        dispatch(addContributionEntities(data));
         dispatch(actionCreators.createContribution.success());
         dispatch(
           flashMessage(`Contribution Added`, {
@@ -227,8 +232,7 @@ export function getContributions(contributionSearchAttrs) {
       } else if (response.status === 200) {
         const contributions = await response.json();
         const data = normalize(contributions.data, [schema.contribution]);
-
-        dispatch(addContributionEntities(data.entities));
+        dispatch(addContributionEntities(data));
         dispatch(actionCreators.getContributions.success(contributions.total));
       } else {
         dispatch(actionCreators.getContributions.failure());
@@ -247,7 +251,7 @@ export function getContributionById(id) {
       if (response.status === 200) {
         // TODO look into why response.json() is removing data
         const data = normalize(await response.json(), schema.contribution);
-        dispatch(addContributionEntities(data.entities));
+        dispatch(addContributionEntities(data));
         dispatch(actionCreators.getContributionById.success(id));
       } else {
         dispatch(actionCreators.getContributionById.failure());
@@ -265,7 +269,7 @@ export function archiveContribution(id) {
       const response = await api.archiveContribution(id);
       if (response.status === 200) {
         const data = normalize(await response.json(), schema.contribution);
-        dispatch(addContributionEntities(data.entities));
+        dispatch(addContributionEntities(data));
         dispatch(actionCreators.archiveContribution.success());
       } else {
         dispatch(actionCreators.archiveContribution.failure());
@@ -299,10 +303,16 @@ export const rootState = state => state || {};
 export const getContributionsList = createSelector(
   rootState,
   state => {
-    if (isEmpty(state.contributions.list)) {
+    if (
+      isEmpty(state.contributions.list) ||
+      isEmpty(state.contributions.listOrder)
+    ) {
       return [];
     }
-    return Object.values(state.contributions.list);
+    return state.contributions.listOrder.map(
+      id => state.contributions.list[id]
+    );
+    // return Object.values(state.contributions.list);
   }
 );
 

--- a/app/src/state/ducks/contributions.test.js
+++ b/app/src/state/ducks/contributions.test.js
@@ -19,6 +19,7 @@ describe('Reducer', () => {
       isLoading: false,
       error: null,
       currentId: 0,
+      listOrder: [],
       total: 0,
     });
   });
@@ -28,8 +29,10 @@ describe('Reducer', () => {
       reducer(undefined, {
         type: ADD_CONTRIBUTION_ENTITIES,
         payload: {
-          contributions: {
-            '1': {},
+          entities: {
+            contributions: {
+              '1': {},
+            },
           },
         },
       })

--- a/app/src/state/ducks/expenditures.test.js
+++ b/app/src/state/ducks/expenditures.test.js
@@ -18,6 +18,7 @@ describe('Reducer', () => {
       error: null,
       list: null,
       currentId: null,
+      listOrder: [],
       total: 0,
     });
   });
@@ -27,8 +28,10 @@ describe('Reducer', () => {
       reducer(undefined, {
         type: ADD_EXPENDITURE_ENTITIES,
         payload: {
-          expenditures: {
-            '1': {},
+          entities: {
+            expenditures: {
+              '1': {},
+            },
           },
         },
       })


### PR DESCRIPTION
Replaces #807 

 Normalize passes back an array with keys in the delivered order. Used those keys with a selector to sort.