### PR TITLE
Bug/remove user gh 820

### DIFF
--- a/app/src/Pages/Portal/ManagePortal/ManageUser/ManageUser.js
+++ b/app/src/Pages/Portal/ManagePortal/ManageUser/ManageUser.js
@@ -21,7 +21,7 @@ const divSpacer = css`
 `;
 
 const ManageUserPage = props => {
-  const { id, email, userStatus } = props.location.state;
+  const { id, name, email, userStatus } = props.location.state;
 
   const handleReSendEmail = () => {
     props.resendUserInvite(id);
@@ -40,8 +40,8 @@ const ManageUserPage = props => {
       </h1>
       <div className="manage-user-container">
         <div className="manage-user-intro">
-          <h1>User Name</h1>
-          <p>{email}</p>
+          <h3>{`User Name: ${name || 'not on record'}`}</h3>
+          <h3>{`Email: ${email || 'not on record'}`}</h3>
           {userStatus === 'invited' && (
             <React.Fragment>
               <p className="fine-print" css={finePrint}>

--- a/app/src/components/FormModal/FormModal.js
+++ b/app/src/components/FormModal/FormModal.js
@@ -5,7 +5,7 @@ import Paper from '@material-ui/core/Paper';
 import { css, jsx } from '@emotion/core';
 
 const formModalWrapper = css`
-  max-width: 350px;
+  max-width: 400px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/app/src/components/Forms/RemoveUser/RemoveUser.js
+++ b/app/src/components/Forms/RemoveUser/RemoveUser.js
@@ -8,7 +8,6 @@ import FormModal from '../../FormModal/FormModal';
 
 const removeUserStyle = css`
   word-break: break-word;
-  max-width: 300px;
 `;
 const buttonContainer = css`
   display: flex;
@@ -27,7 +26,8 @@ const RemoveUser = props => {
       <div css={removeUserStyle}>
         <h1 css={removeUserTitle}>Remove User </h1>
         <p>
-          {props.location.state.email} will no longer have access to the portal.
+          {props.location.state.email || props.location.state.name} will no
+          longer have access to the portal.
         </p>
         <p>Are you sure you want to remove them?</p>
         <div css={buttonContainer}>

--- a/app/src/components/Modal/Modal.js
+++ b/app/src/components/Modal/Modal.js
@@ -9,7 +9,7 @@ import * as ModalOptions from '../Forms/ModalForms';
 
 const modalStyle = css`
   position: absolute;
-  width: 350px;
+  width: 400px;
   background: white;
   top: 8vh;
   left: calc(50vw - 175px);


### PR DESCRIPTION
```     
WIP- pass name to removeUser, in addition to email being passed

    - because the campaigns in our db don't currently have emails listed,
    the email won't populate the sentence about who is being
    removed
    - by passing the name and email, whichever is present (or both) appear
    - however campaigns still fail on submit of removeUser
```

I'm guessing this will be quick for someone to finish, or you can leave it for me next week. Someone who's a decision maker should look it over though, since I changed the view to include  both the name and the email. The email populates the sentence on the removeUser modal, unless there is no email, in which case, it uses the name.  In both cases the id is passed still, so it should be able to delete the record based on that... but it's not, so I'm missing some part still. 

The other question I have is whether removing a campaign uses the same endpoint as removing a user, and needs a `permissionId`.  If so, what is that? And, if not, is there an endpoint for removing a campaign?  

No user name:
![image](https://user-images.githubusercontent.com/6107653/64901201-8abc5380-d64b-11e9-9212-9a681a24399c.png)

No email: 
![image](https://user-images.githubusercontent.com/6107653/64901220-b8a19800-d64b-11e9-8807-a299e2a1ecd7.png)
