### PR TITLE
remove Manage button from Campaigns view

### DIFF
--- a/app/src/Pages/Portal/ManageCampaign/ManageCampaign.js
+++ b/app/src/Pages/Portal/ManageCampaign/ManageCampaign.js
@@ -56,19 +56,19 @@ const ManageCampaign = ({ isCampaignListLoading, campaignList, ...props }) => {
                   Add New Campaign
                 </Button>
               }
-              actions={[
-                {
-                  icon: 'none', // icon is needed here or it will error.
-                  name: 'Manage',
-                  buttonType: 'manage',
-                  onClick: (event, rowData) => {
-                    props.history.push({
-                      pathname: '/manage-portal/manage-user',
-                      state: rowData,
-                    });
-                  },
-                },
-              ]}
+              // actions={[
+              //   {
+              //     icon: 'none', // icon is needed here or it will error.
+              //     name: 'Manage',
+              //     buttonType: 'manage',
+              //     onClick: (event, rowData) => {
+              //       props.history.push({
+              //         pathname: '/manage-portal/manage-user',
+              //         state: rowData,
+              //       });
+              //     },
+              //   },
+              // ]}
               components={{
                 Action: props => (
                   <Button


### PR DESCRIPTION
Closes GH 823- https://github.com/hackoregon/openelections/pull/823

Manage Campaign button currently doesn't have a purpose here.  I commented it out instead of removing it because it may have value in the nearish future.

To test:

- [ ] log in a govAdmin
- [ ] click the Campaigns tab of the sidebar
- [ ] the list of campaigns should no longer have a Manage button