### PR TITLE
make check number only required for money orders & on expenses

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
@@ -641,11 +641,12 @@ export const validate = values => {
     if (isEmpty(inKindType)) error.inKindType = 'Inkind type is required';
   }
 
-  if (visible.checkSelected && isEmpty(checkNumber)) {
-    error.checkNumber =
-      paymentMethod === PaymentMethodEnum.CHECK
-        ? 'Check number is required.'
-        : 'Money Order number is required.';
+  if (
+    visible.checkSelected &&
+    paymentMethod === PaymentMethodEnum.MONEY_ORDER &&
+    isEmpty(checkNumber)
+  ) {
+    error.checkNumber = 'Money Order number is required.';
   }
 
   if (


### PR DESCRIPTION
closes #860 

- still shows check number field for checks on contributions, but no
longer is required
- check number still required for money orders on contributions