### PR TITLE
Enable qa api access from a local dev env

### DIFF
--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -416,13 +416,15 @@ export function baseUrl() {
   if (process.env.NODE_ENV === 'test') {
     return 'http://localhost:3000';
   }
-  if (process.env.NODE_ENV === 'development') {
-    return 'http://localhost:3000';
-  }
 
   if (window && window.location.hostname.includes('qa')) {
     return 'https://api-qa.openelectionsportland.org';
   }
+
+  if (process.env.NODE_ENV === 'development') {
+    return 'http://localhost:3000';
+  }
+
   return 'https://api.openelectionsportland.org';
 }
 

--- a/app/src/state/ducks/auth.js
+++ b/app/src/state/ducks/auth.js
@@ -153,8 +153,11 @@ export function logout() {
 // Side Effects, e.g. thunks
 export function me() {
   return async (dispatch, getState, { api }) => {
-    if (!document.cookie.includes('token') && !process.env.TOKEN) {
-      // dont attempt if there is no token.
+    if (
+      process.env.NODE_ENV !== 'development' &&
+      !document.cookie.includes('token') &&
+      !process.env.TOKEN
+    ) {
       return;
     }
     dispatch(actionCreators.me.request());


### PR DESCRIPTION
When attempting to access qa api locally, authentication is returned before setting the state. So requests work but permissions are not set. This pull fixes that problem and enables the dev to switch which api is use by loading the client on alternative localhost urls:

qa.localhost:4000 -> api-qa.openelectionsportland.org
localhost:4000 -> localhost:3000