### PR TITLE
make disabled fields less grey - closes 893

### DIFF
--- a/app/src/components/ReadOnly/index.js
+++ b/app/src/components/ReadOnly/index.js
@@ -5,7 +5,7 @@ export default class ReadOnly extends React.Component {
   render() {
     const { ro = false, children } = this.props;
     return (
-      <div style={ro ? { pointerEvents: 'none', opacity: '0.7' } : null}>
+      <div style={ro ? { pointerEvents: 'none', opacity: '0.9' } : null}>
         {children}
       </div>
     );


### PR DESCRIPTION
changes opacity from `0.7` to `0.9` 
closes #893 

I didn't remove all opacity, but made it less grey.  Comments about it and views of options are logged in issue #893 