### PR TITLE
Ui updates gh 922

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsSections.js
@@ -79,7 +79,7 @@ export const ViewHeaderSection = ({
                         handleSubmit();
                       }}
                     >
-                      Archive
+                      Move to trash
                     </Button>
                     <Button
                       css={headerStyles.submitButton}
@@ -90,7 +90,7 @@ export const ViewHeaderSection = ({
                         handleSubmit();
                       }}
                     >
-                      Save
+                      Save Draft
                     </Button>
                   </>
                 ) : null}

--- a/app/src/components/Forms/AddContribution/index.js
+++ b/app/src/components/Forms/AddContribution/index.js
@@ -40,6 +40,8 @@ const AddContribution = ({ ...props }) => (
     initialValues={{
       typeOfContribution: ContributionTypeEnum.CONTRIBUTION,
       typeOfContributor: ContributorTypeEnum.INDIVIDUAL,
+      city: 'Portland',
+      state: 'OR',
       employerCountry: 'United States',
     }}
   >


### PR DESCRIPTION
addresses some items on #922 
 - sets 'Portland' and 'OR' as initial values when adding a contribution
- updates text of 'Save' to 'Save Draft' and 'Archive' to 'Move to trash'
 
remaining items are awaiting responses
