### PR TITLE
add type & subtype to expense table

### DIFF
--- a/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
+++ b/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
@@ -53,6 +53,30 @@ const columns = isGovAdmin => [
     title: 'Name',
   },
   {
+    field: 'type',
+    title: 'Expenditure Type',
+    render: rowData => {
+      return rowData.type
+        ? (rowData.type[0].toUpperCase() + rowData.type.slice(1)).replace(
+            /_/g,
+            ' '
+          )
+        : '';
+    },
+  },
+  {
+    field: 'subType',
+    title: 'Expenditure Subtype',
+    render: rowData => {
+      return rowData.subType
+        ? (rowData.subType[0].toUpperCase() + rowData.subType.slice(1)).replace(
+            /_/g,
+            ' '
+          )
+        : '';
+    },
+  },
+  {
     field: 'amount',
     title: 'Amount',
     type: 'currency',


### PR DESCRIPTION
```
If both the type and subtype are altered, it’s not recognizing subtype
 as an altered value.

It seems to occur when the subtype has an initial default that changes
with the type change.  The user doesn’t make the change, it happens 
automatically by selecting the type.
```