### PR TITLE
Expense date clarity gh 924

### DIFF
--- a/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
+++ b/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
@@ -25,7 +25,7 @@ const actionInfo = (name, buttonType, onClick, isFreeAction = undefined) =>
 const columns = isGovAdmin => [
   {
     field: 'date',
-    title: 'Date',
+    title: 'Expenditure Date',
     render: rowData =>
       new Date(rowData.date)
         .toLocaleString('en-US', {

--- a/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
+++ b/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
@@ -36,6 +36,17 @@ const columns = isGovAdmin => [
         .split(', ')[0],
   },
   {
+    title: 'Date Submitted',
+    render: rowData =>
+      new Date(rowData.createdAt)
+        .toLocaleString('en-US', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        })
+        .split(', ')[0],
+  },
+  {
     ...(isGovAdmin
       ? {
           field: 'campaign',


### PR DESCRIPTION
closes #924 

- clarifies date as "Expenditure Date"
- creates new column for "Date Submitted" showing original record creation date (not updatedAt)