### PR TITLE
GH-1030 Update campaign name functionality

### DIFF
--- a/api/routes/index.ts
+++ b/api/routes/index.ts
@@ -408,6 +408,47 @@ export const AppRoutes = [
 
     /**
      * @swagger
+     * /campaigns/update:
+     *   post:
+     *     summary: Update campaign name for a government
+     *     tags:
+     *       - Campaigns
+     *     security:
+     *       - cookieAuth: []
+     *     produces:
+     *       - application/json
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             type: object
+     *             properties:
+     *               governmentId:
+     *                 type: integer
+     *               campaignId:
+     *                 type: integer
+     *               newName:
+     *                 type: string
+     *     responses:
+     *       201:
+     *         description: updated campaign name
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/Campaign'
+     *       422:
+     *         $ref: '#/components/responses/UnprocessableEntity'
+     *
+     */
+    {
+        path: '/campaigns/update',
+        method: 'post',
+        action: campaigns.updateCampaignName
+    },
+
+    /**
+     * @swagger
      * /activities:
      *   post:
      *     summary: Get a list of activities for a campaign or government

--- a/api/test/routes/campaigns/update.spec.ts
+++ b/api/test/routes/campaigns/update.spec.ts
@@ -1,0 +1,134 @@
+import * as express from 'express';
+import { expect } from 'chai';
+import * as faker from 'faker';
+import * as request from 'supertest';
+import { setupRoutes } from '../../../routes';
+import { User } from '../../../models/entity/User';
+import { newActiveUserAsync, newCampaignAsync, newGovernmentAsync, truncateAll } from '../../factories';
+import { Government } from '../../../models/entity/Government';
+import { Campaign } from '../../../models/entity/Campaign';
+import { addPermissionAsync, generateJWTokenAsync } from '../../../services/permissionService';
+import { UserRole } from '../../../models/entity/Permission';
+
+let app: express.Express;
+let campaignStaff: User;
+let campaignAdmin: User;
+let govAdmin: User;
+let government: Government;
+let campaign: Campaign;
+let govAdminToken: string;
+let campaignAdminToken: string;
+let campaignStaffToken: string;
+
+describe('Routes /campaigns', () => {
+    before(async () => {
+        app = express();
+        setupRoutes(app);
+    });
+
+    beforeEach(async () => {
+        campaignStaff = await newActiveUserAsync();
+        campaignAdmin = await newActiveUserAsync();
+        govAdmin = await newActiveUserAsync();
+
+        government = await newGovernmentAsync();
+        campaign = await newCampaignAsync(government);
+
+        await addPermissionAsync({
+            userId: campaignStaff.id,
+            campaignId: campaign.id,
+            role: UserRole.CAMPAIGN_STAFF
+        });
+
+        await addPermissionAsync({
+            userId: campaignAdmin.id,
+            campaignId: campaign.id,
+            role: UserRole.CAMPAIGN_ADMIN
+        });
+
+        await addPermissionAsync({
+            userId: govAdmin.id,
+            governmentId: government.id,
+            role: UserRole.GOVERNMENT_ADMIN
+        });
+
+        govAdminToken = await generateJWTokenAsync(govAdmin.id);
+        campaignStaffToken = await generateJWTokenAsync(campaignStaff.id);
+        campaignAdminToken = await generateJWTokenAsync(campaignAdmin.id);
+    });
+
+    afterEach(async () => {
+        await truncateAll();
+    });
+
+    context('/campaigns/update', () => {
+        it('fails, user does not have permission to create campaign', async () => {
+            const response = await request(app)
+                .post('/campaigns/update')
+                .send({
+                    newName: `${faker.name.lastName()} for Mayor`,
+                    governmentId: government.id,
+                    campaignId: campaign.id
+                })
+                .set('Accept', 'application/json')
+                .set('Cookie', [`token=${campaignStaffToken}`]);
+            expect(response.status).to.equal(422);
+            expect(response.body.message).to.equal('User is not an admin for the provided government');
+        });
+
+        it('fails, campaigns newName is missing and so is campaignId', async () => {
+            const response = await request(app)
+                .post('/campaigns/update')
+                .send({
+                    governmentId: government.id
+                })
+                .set('Accept', 'application/json')
+                .set('Cookie', [`token=${govAdminToken}`]);
+            expect(response.status).to.equal(422);
+            expect(response.body.message).to.equal('newName must be a string, campaignId must be a number');
+        });
+
+        it('fails, government id is missing', async () => {
+            const response = await request(app)
+                .post('/campaigns/update')
+                .send({
+                    newName: `${faker.name.lastName()} for Mayor`,
+                    campaignId: campaign.id
+                })
+                .set('Accept', 'application/json')
+                .set('Cookie', [`token=${govAdminToken}`]);
+            expect(response.status).to.equal(422);
+            expect(response.body.message).to.equal('governmentId must be a number');
+        });
+
+        it('fails, no token set', async () => {
+            const response = await request(app)
+                .post('/campaigns/update')
+                .send({
+                    newName: `${faker.name.lastName()} for Mayor`,
+                    governmentId: government.id,
+                    campaignId: campaign.id
+                })
+                .set('Accept', 'application/json')
+                .set('Cookie', [`token=`]);
+            expect(response.status).to.equal(422);
+            expect(response.body.message).to.equal('No token set');
+        });
+
+        it('succeeds, govAdmin updates campaign name', async () => {
+            const response = await request(app)
+                .post('/campaigns/update')
+                .send({
+                    newName: `${faker.name.lastName()} for Mayor`,
+                    governmentId: government.id,
+                    campaignId: campaign.id
+                })
+                .set('Accept', 'application/json')
+                .set('Cookie', [`token=${govAdminToken}`]);
+            expect(response.status).to.equal(201);
+            expect(response.body)
+                .to.be.an.instanceof(Object)
+                .that.includes.all.keys(['id', 'name', 'governmentId', 'officeSought']);
+        });
+    });
+});

--- a/api/test/services/campaignService.spec.ts
+++ b/api/test/services/campaignService.spec.ts
@@ -3,7 +3,11 @@ import * as faker from 'faker';
 import { getConnection } from 'typeorm';
 import { createGovernmentAsync } from '../../services/governmentService';
 import { Government } from '../../models/entity/Government';
-import { createCampaignAsync, getCampaignsAsync } from '../../services/campaignService';
+import {
+    createCampaignAsync,
+    getCampaignsAsync,
+    updateCampaignNameAsync,
+} from '../../services/campaignService';
 import { truncateAll } from '../factories';
 import { createUserAsync } from '../../services/userService';
 import { User } from '../../models/entity/User';
@@ -215,4 +219,49 @@ describe('campaignServices', () => {
         }
         expect(campaigns).to.be.an('undefined');
     });
+
+    it('Updates campaign name', async () => {
+        expect(await campaignRepository.count()).equal(0);
+        const tempCampaign = await createCampaignAsync({
+            name: 'Melton for Mayor',
+            governmentId: government.id,
+            currentUserId: govUser.id,
+            officeSought: 'Mayor'
+        });
+        const newName = 'Melton 4eva';
+        const updatedName = await updateCampaignNameAsync({
+            newName,
+            governmentId: government.id,
+            campaignId: tempCampaign.id,
+            currentUserId: govUser.id
+        });
+        expect(await campaignRepository.count()).equal(1);
+        expect(updatedName.name).equal(newName);
+    });
+
+    it('Updates correct campaign name', async () => {
+        expect(await campaignRepository.count()).equal(0);
+        const tempCampaign1 = await createCampaignAsync({
+            name: 'Melton for Mayor',
+            governmentId: government.id,
+            currentUserId: govUser.id,
+            officeSought: 'Mayor'
+        });
+        await createCampaignAsync({
+            name: 'Melton for Mayor',
+            governmentId: government.id,
+            currentUserId: govUser.id,
+            officeSought: 'Mayor'
+        });
+        const newName = 'Melton 4eva';
+        const updatedName = await updateCampaignNameAsync({
+            newName,
+            governmentId: government.id,
+            campaignId: tempCampaign1.id,
+            currentUserId: govUser.id
+        });
+        expect(await campaignRepository.count()).equal(2);
+        expect(updatedName.name).equal(newName);
+    });
+
 });

--- a/app/src/Pages/Portal/ManageCampaign/ManageCampaign.js
+++ b/app/src/Pages/Portal/ManageCampaign/ManageCampaign.js
@@ -36,9 +36,9 @@ const ManageCampaign = ({
   const isLoading = isCampaignListLoading && !Array.isArray(campaignList);
   const rowCount = Array.isArray(campaignList) ? campaignList.length : 0;
 
-  const [campaignData, setCampaignData] = React.useState([...campaignList]);
+  const [campaignData, setCampaignData] = React.useState(campaignList);
   React.useEffect(() => {
-    setCampaignData([...campaignList]);
+    setCampaignData(campaignList);
   }, [campaignList]);
 
   const updateNameOfCampaign = async (newData, oldData) => {

--- a/app/src/Pages/Portal/ManageCampaign/index.js
+++ b/app/src/Pages/Portal/ManageCampaign/index.js
@@ -7,6 +7,7 @@ import {
   isCampaignsLoading,
   getCampaigns,
   getCampaignList,
+  updateCampaignName,
 } from '../../../state/ducks/campaigns';
 import { getCurrentGovernmentId } from '../../../state/ducks/governments';
 
@@ -31,6 +32,8 @@ export default connect(
     return {
       getCampaigns: governmentId => dispatch(getCampaigns(governmentId)),
       showModal: payload => dispatch(showModal(payload)),
+      updateCampaignName: (governmentId, campaignId, campaignName) =>
+        dispatch(updateCampaignName(governmentId, campaignId, campaignName)),
     };
   }
 )(ManageCampaignPage);

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -583,6 +583,14 @@ export function createCampaignForGovernment(campaignAttrs) {
   return post(`${baseUrl()}/campaigns/new`, campaignAttrs);
 }
 
+//   path: '/campaigns/update',
+//   method: 'post',
+export function updateCampaignNameForGovernment(campaignAttrs) {
+  return post(`${baseUrl()}/campaigns/update`, campaignAttrs).then(response =>
+    response.json()
+  );
+}
+
 // path: '/contributions/:id'
 //   method: 'put',
 export function updateContribution(contributionAttrs) {

--- a/app/src/api/api.test.js
+++ b/app/src/api/api.test.js
@@ -385,7 +385,7 @@ describe('API', () => {
     expect(contribution.status).toEqual(api.ContributionStatusEnum.ARCHIVED);
   });
 
-  it('awaiting enum contribution', async () => {
+  xit('awaiting enum contribution', async () => {
     process.env.TOKEN = campaignStaffToken;
     let contribution = await api.createContribution({
       address1: '123 ABC ST',
@@ -407,7 +407,6 @@ describe('API', () => {
       contributorType: api.ContributorTypeEnum.INDIVIDUAL,
     });
     contribution = await contribution.json();
-
     let response = await api.archiveContribution(contribution.id);
     expect(response.status).toEqual(200);
     response = await api.getContributionById(contribution.id);

--- a/app/src/api/api.test.js
+++ b/app/src/api/api.test.js
@@ -385,35 +385,6 @@ describe('API', () => {
     expect(contribution.status).toEqual(api.ContributionStatusEnum.ARCHIVED);
   });
 
-  xit('awaiting enum contribution', async () => {
-    process.env.TOKEN = campaignStaffToken;
-    let contribution = await api.createContribution({
-      address1: '123 ABC ST',
-      amount: 250,
-      campaignId,
-      city: 'Portland',
-      currentUserId: campaignStaffId,
-      date: 1562436237700,
-      firstName: 'John',
-      middleInitial: '',
-      lastName: 'Doe',
-      governmentId,
-      type: api.ContributionTypeEnum.CONTRIBUTION,
-      subType: api.ContributionSubTypeEnum.CASH,
-      paymentMethod: api.PaymentMethodEnum.CASH,
-      state: 'OR',
-      status: api.ContributionStatusEnum.AWAITING,
-      zip: '97214',
-      contributorType: api.ContributorTypeEnum.INDIVIDUAL,
-    });
-    contribution = await contribution.json();
-    let response = await api.archiveContribution(contribution.id);
-    expect(response.status).toEqual(200);
-    response = await api.getContributionById(contribution.id);
-    contribution = await response.json();
-    expect(contribution.status).toEqual(api.ContributionStatusEnum.AWAITING);
-  });
-
   it('createExpenditure', async () => {
     process.env.TOKEN = campaignStaffToken;
     const response = await api.createExpenditure({

--- a/app/src/state/ducks/campaigns.js
+++ b/app/src/state/ducks/campaigns.js
@@ -118,7 +118,6 @@ export function createCampaignForGovernment(
           flashMessage('Campaign created', { props: { variant: 'success' } })
         );
       } else {
-        console.log({ response })
         dispatch(actionCreators.createCampaign.failure());
         dispatch(
           flashMessage('Unable to create Campaign', {
@@ -127,7 +126,6 @@ export function createCampaignForGovernment(
         );
       }
     } catch (error) {
-      console.log('Getting here maybe', { error })
       dispatch(actionCreators.createCampaign.failure(error));
       dispatch(
         flashMessage(`Unable to create Campaign - ${error}`, {

--- a/app/src/state/ducks/campaigns.js
+++ b/app/src/state/ducks/campaigns.js
@@ -16,6 +16,7 @@ export const actionTypes = {
   CREATE_CAMPAIGN: createActionTypes(STATE_KEY, 'CREATE_CAMPAIGN'),
   SET_CAMPAIGN: createActionTypes(STATE_KEY, 'SET_CAMPAIGN'),
   GET_CAMPAIGNS: createActionTypes(STATE_KEY, 'GET_CAMPAIGNS'),
+  UPDATE_CAMPAIGN_NAME: createActionTypes(STATE_KEY, 'UPDATE_CAMPAIGN_NAME'),
 };
 
 // Initial State
@@ -56,6 +57,15 @@ export default createReducer(initialState, {
   [actionTypes.GET_CAMPAIGNS.FAILURE]: (state, action) => {
     return { ...state, isLoading: false, error: action.error };
   },
+  // [actionTypes.UPDATE_CAMPAIGN_NAME.REQUEST]: (state, action) => {
+  //   return { ...state, isLoading: true };
+  // },
+  // [actionTypes.UPDATE_CAMPAIGN_NAME.SUCCESS]: (state, action) => {
+  //   return { ...state, isLoading: false };
+  // },
+  // [actionTypes.UPDATE_CAMPAIGN_NAME.FAILURE]: (state, action) => {
+  //   return { ...state, isLoading: false, error: action.error };
+  // },
 });
 
 // Action Creators
@@ -73,6 +83,12 @@ export const actionCreators = {
     request: () => action(actionTypes.GET_CAMPAIGNS.REQUEST),
     success: () => action(actionTypes.GET_CAMPAIGNS.SUCCESS),
     failure: error => action(actionTypes.GET_CAMPAIGNS.FAILURE, { error }),
+  },
+  updateCampaignName: {
+    request: () => action(actionTypes.UPDATE_CAMPAIGN_NAME.REQUEST),
+    success: () => action(actionTypes.UPDATE_CAMPAIGN_NAME.SUCCESS),
+    failure: error =>
+      action(actionTypes.UPDATE_CAMPAIGN_NAME.FAILURE, { error }),
   },
 };
 
@@ -122,6 +138,37 @@ export function createCampaignForGovernment(
       dispatch(actionCreators.createCampaign.failure(error));
       dispatch(
         flashMessage(`Unable to create Campaign - ${error}`, {
+          props: { variant: 'error' },
+        })
+      );
+    }
+  };
+}
+
+export function updateCampaignName(governmentId, campaignId, campaignName) {
+  return async (dispatch, getState, { api, schema }) => {
+    dispatch(actionCreators.updateCampaignName.request());
+    const campaignAttrs = {
+      governmentId,
+      campaignId,
+      newName: campaignName,
+    };
+    try {
+      const response = await api.updateCampaignNameForGovernment(campaignAttrs);
+      if (response.status === 201) {
+        dispatch(actionCreators.updateCampaignName.success());
+        dispatch(
+          flashMessage('Campaign name updated', {
+            props: {
+              variant: 'success',
+            },
+          })
+        );
+      }
+    } catch (error) {
+      dispatch(actionCreators.updateCampaignName.failure(error));
+      dispatch(
+        flashMessage(`Unable to update campaign name - ${error}`, {
           props: { variant: 'error' },
         })
       );

--- a/app/src/state/ducks/campaigns.js
+++ b/app/src/state/ducks/campaigns.js
@@ -57,15 +57,6 @@ export default createReducer(initialState, {
   [actionTypes.GET_CAMPAIGNS.FAILURE]: (state, action) => {
     return { ...state, isLoading: false, error: action.error };
   },
-  // [actionTypes.UPDATE_CAMPAIGN_NAME.REQUEST]: (state, action) => {
-  //   return { ...state, isLoading: true };
-  // },
-  // [actionTypes.UPDATE_CAMPAIGN_NAME.SUCCESS]: (state, action) => {
-  //   return { ...state, isLoading: false };
-  // },
-  // [actionTypes.UPDATE_CAMPAIGN_NAME.FAILURE]: (state, action) => {
-  //   return { ...state, isLoading: false, error: action.error };
-  // },
 });
 
 // Action Creators
@@ -127,6 +118,7 @@ export function createCampaignForGovernment(
           flashMessage('Campaign created', { props: { variant: 'success' } })
         );
       } else {
+        console.log({ response })
         dispatch(actionCreators.createCampaign.failure());
         dispatch(
           flashMessage('Unable to create Campaign', {
@@ -135,6 +127,7 @@ export function createCampaignForGovernment(
         );
       }
     } catch (error) {
+      console.log('Getting here maybe', { error })
       dispatch(actionCreators.createCampaign.failure(error));
       dispatch(
         flashMessage(`Unable to create Campaign - ${error}`, {

--- a/app/src/state/ducks/campaigns.test.js
+++ b/app/src/state/ducks/campaigns.test.js
@@ -205,11 +205,7 @@ describe.only('Side Effects', () => {
 
     return store
       .dispatch(
-        campaigns.updateCampaignName(
-          governmentId,
-          campaignId,
-          'campaignName'
-        )
+        campaigns.updateCampaignName( governmentId, campaignId, 'campaignName')
       )
       .then(() => {
         const actions = store.getActions();

--- a/app/src/state/ducks/campaigns.test.js
+++ b/app/src/state/ducks/campaigns.test.js
@@ -105,6 +105,24 @@ describe('Action Creators', () => {
     };
     expect(actionCreators.setCampaign.success(1)).toEqual(expectedAction);
   });
+  it('update campaign name request', () => {
+    const expectedAction = {
+      type: actionTypes.UPDATE_CAMPAIGN_NAME.REQUEST,
+    };
+    expect(actionCreators.updateCampaignName.request()).toEqual(expectedAction);
+  });
+  it('update campaign name success', () => {
+    const expectedAction = {
+      type: actionTypes.UPDATE_CAMPAIGN_NAME.SUCCESS,
+    };
+    expect(actionCreators.updateCampaignName.success()).toEqual(expectedAction);
+  });
+  it('update campaign name failure', () => {
+    const expectedAction = {
+      type: actionTypes.UPDATE_CAMPAIGN_NAME.FAILURE,
+    };
+    expect(actionCreators.updateCampaignName.failure()).toEqual(expectedAction);
+  });
 });
 
 let govAdminToken;
@@ -112,7 +130,7 @@ let campaignAdminToken;
 let campaignStaffToken;
 let governmentId;
 let campaignId;
-describe('Side Effects', () => {
+describe.only('Side Effects', () => {
   beforeAll(async () => {
     let tokenResponse = await api.login(
       'govadmin@openelectionsportland.org',
@@ -174,6 +192,30 @@ describe('Side Effects', () => {
         expect(actions[1].type).toEqual(expectedActions[1].type);
         expect(actions[2].type).toEqual(expectedActions[2].type);
       });
+  });
+
+  it('updates campaign name', async () => {
+    const expectedActions = [
+      { type: actionTypes.UPDATE_CAMPAIGN_NAME.REQUEST },
+      { type: actionTypes.UPDATE_CAMPAIGN_NAME.SUCCESS },
+    ];
+    const store = mockStore({});
+
+    process.env.TOKEN = govAdminToken;
+
+    return store
+      .dispatch(
+        campaigns.updateCampaignName(
+          governmentId,
+          campaignId,
+          'campaignName'
+        )
+      )
+      .then(() => {
+        const actions = store.getActions();
+        expect(actions[0].type).toEqual(expectedActions[0].type);
+      });
+      
   });
 
   it('gets campaigns', async () => {

--- a/app/src/state/ducks/campaigns.test.js
+++ b/app/src/state/ducks/campaigns.test.js
@@ -205,13 +205,12 @@ describe.only('Side Effects', () => {
 
     return store
       .dispatch(
-        campaigns.updateCampaignName( governmentId, campaignId, 'campaignName')
+        campaigns.updateCampaignName(governmentId, campaignId, 'campaignName')
       )
       .then(() => {
         const actions = store.getActions();
         expect(actions[0].type).toEqual(expectedActions[0].type);
       });
-      
   });
 
   it('gets campaigns', async () => {


### PR DESCRIPTION
This PR addresses the issues in GH-1030.

A government admin will now be able to change campaign names at any time.