### PR TITLE
Resolve issues per QA review

### DIFF
--- a/app/src/Pages/Home/Home.js
+++ b/app/src/Pages/Home/Home.js
@@ -213,7 +213,7 @@ const Home = ({
         component: 'Info',
         props: {},
       });
-  });
+  }, [showModal, cookies.visited]);
 
   const isLoading = request ? request.isLoading : true;
   const error = request && request.error;

--- a/app/src/components/Forms/Info/DetailedInfo.js
+++ b/app/src/components/Forms/Info/DetailedInfo.js
@@ -223,7 +223,7 @@ const DetailedInfo = () => (
           <p>
             The information above includes both monetary and non-monetary
             (in-kind) contributions. Program rules limit in-kind contributions
-            to $20,000 per campaign.
+            to $20,000 per campaign per election.
           </p>
           <p>
             When a contribution is on the border of a size category, it is


### PR DESCRIPTION
Per review with @susanmottet:
- clarified that $20,000 in-kind limit is per campaign per election (primary and general)
- resolved issue with Info modal firing on after initial visit