### PR TITLE
change pm2 version to 12 for node 11 env

### DIFF
--- a/api/Dockerfile.jobs
+++ b/api/Dockerfile.jobs
@@ -7,7 +7,7 @@ RUN npm install
 COPY . /app
 RUN /app/node_modules/.bin/tsc --build /app/tsconfig.json
 
-FROM keymetrics/pm2:latest-alpine
+FROM keymetrics/pm2:12-alpine
 LABEL maintainer "Dan Melton <dan@civicsoftwarefoundation.org>"
 
 WORKDIR /app

--- a/api/Dockerfile.production
+++ b/api/Dockerfile.production
@@ -7,7 +7,7 @@ RUN npm install
 COPY . /app
 RUN /app/node_modules/.bin/tsc --build /app/tsconfig.json
 
-FROM keymetrics/pm2:latest-alpine
+FROM keymetrics/pm2:12-alpine
 LABEL maintainer "Dan Melton <dan@civicsoftwarefoundation.org>"
 
 WORKDIR /app

--- a/api/app.ts
+++ b/api/app.ts
@@ -34,7 +34,7 @@ const corsOptions = {
     app.use(fileUpload({
         createParentPath: true,
         limits: {
-            fileSize: 10 * 1024 * 1024 * 1024 //10MB max file(s) size
+            fileSize: 10 * 1024 * 1024 * 1024 // 10MB max file(s) size
         },
         useTempFiles : true,
         tempFileDir : '/app/uploads',


### PR DESCRIPTION
It looks like pm2 is failing to spin up new docker env in staging and prod. Current idea is that our current node version and the pm2 version are not playing nice together.