### PR TITLE
Audit query sort fields

### DIFF
--- a/api/models/entity/Expenditure.ts
+++ b/api/models/entity/Expenditure.ts
@@ -394,16 +394,21 @@ export async function getExpendituresByGovernmentIdAsync(
 
         if (sort) {
             if (!['date', 'status', 'campaignId'].includes(sort.field)) {
-                throw new Error('Sort.field must be one of date, status or campaignid');
+                throw new Error('Sort.field must be one of date, status or campaignId');
             }
 
             if (!['ASC', 'DESC'].includes(sort.direction)) {
                 throw new Error('Sort.direction must be one of ASC or DESC');
             }
+            let sortField: 'campaignId' | 'status' | 'date' | 'id' = sort.field;
+            if (sortField === 'campaignId') {
+                sortField = 'id';
+            }
 
-            query.order = { [sort.field]: sort.direction };
+            query.order = { [sortField]: sort.direction };
 
         }
+        console.log('This far?');
         const expenditures = (await expenditureRepository.find(removeUndefined(query))  as IExpenditureSummary[]).map((item: any): any => {
             const json = item.toJSON();
             json.campaign = {

--- a/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
+++ b/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
@@ -102,7 +102,7 @@ const columns = isGovAdmin => {
 
   if (isGovAdmin)
     cols.splice(1, 0, {
-      field: 'campaign',
+      field: 'campaignId',
       title: 'Campaign',
       sorting: false,
       render: rowData => {

--- a/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
+++ b/app/src/Pages/Portal/Expenses/ExpensesTable/ExpensesTable.js
@@ -66,7 +66,7 @@ const columns = isGovAdmin => [
   {
     ...(isGovAdmin
       ? {
-          field: 'campaign',
+          field: 'campaignId',
           title: 'Campaign',
           render: rowData => {
             return rowData && rowData.campaign
@@ -79,11 +79,13 @@ const columns = isGovAdmin => [
   {
     field: 'name',
     title: 'Name',
+    sorting: false,
   },
   {
     field: 'amount',
     title: 'Amount',
     type: 'currency',
+    sorting: false,
   },
   {
     field: 'paymentMethod',
@@ -93,6 +95,7 @@ const columns = isGovAdmin => [
         ? rowData.paymentMethod.replace(/_/g, ' ')
         : '';
     },
+    sorting: false,
   },
   {
     field: 'status',

--- a/app/src/components/PreviousDonations/PreviousDonationsTable.js
+++ b/app/src/components/PreviousDonations/PreviousDonationsTable.js
@@ -24,7 +24,7 @@ const columns = [
     },
   },
   {
-    field: 'campaign',
+    field: 'campaignId',
     render: rowData => {
       return rowData && rowData.campaign ? rowData.campaign.name : 'Loading...';
     },
@@ -32,6 +32,7 @@ const columns = [
   {
     field: 'amount',
     type: 'currency',
+    sorting: false,
   },
   {
     field: 'date',


### PR DESCRIPTION
We've been trying to do advanced queries from the front end that the backend does not support. This _hopefully_ brings parity to front & back.