### PR TITLE
Fallback to default connection

### DIFF
--- a/api/models/db.ts
+++ b/api/models/db.ts
@@ -1,12 +1,18 @@
 import 'reflect-metadata';
-import { createConnection, Connection } from 'typeorm';
+import { createConnection, Connection, getConnectionManager } from 'typeorm';
 import ORMConfig from './ormconfig';
 export default async (): Promise<Connection> => {
-    const connection: Connection = await createConnection(ORMConfig);
-    // This is safe to do in prod and dev because it tracks what migrations have ran already in the db.
-    if (process.env.NODE_ENV === 'production') {
-        // If migrations are needed, use this code:
-        // await connection.runMigrations();
+    try {
+        const connection: Connection = await createConnection(ORMConfig);
+        // This is safe to do in prod and dev because it tracks what migrations have ran already in the db.
+        if (process.env.NODE_ENV === 'production') {
+            // If migrations are needed, use this code:
+            // await connection.runMigrations();
+        }
+        return connection;
+    } catch (error) {
+        console.log('Using existing default db connection.');
+        const existingConnection = getConnectionManager().get('default');
+        return existingConnection;
     }
-    return connection;
 };

--- a/api/models/entity/Expenditure.ts
+++ b/api/models/entity/Expenditure.ts
@@ -408,7 +408,7 @@ export async function getExpendituresByGovernmentIdAsync(
             query.order = { [sortField]: sort.direction };
 
         }
-        console.log('This far?');
+
         const expenditures = (await expenditureRepository.find(removeUndefined(query))  as IExpenditureSummary[]).map((item: any): any => {
             const json = item.toJSON();
             json.campaign = {


### PR DESCRIPTION
When the `openelections_jobs` are running, we are seeing this error: 
```
AlreadyHasActiveConnectionError Cannot create a new connection named "default",
because connection with such name already exist and it now has an active connection session.
```
If there is more than one job in the bull queue, it will try to create an existing connection. This allows it to fall back to the existing connection if there is one.