### PR TITLE
Only run jobs in Prod

### DIFF
--- a/api/jobs/processors/dataScienceRetrieverProcessor.ts
+++ b/api/jobs/processors/dataScienceRetrieverProcessor.ts
@@ -1,16 +1,13 @@
 import { getGISCoordinates, retrieveAndSaveMatchResultAsync } from '../../services/contributionService';
 import db from '../../models/db';
-import { renderError } from '../helpers/addJobs';
 
-export default (job: {data: any}, done: any): Promise<any> => {
-    return db().then(async () => {
+export default async (job: {data: any}): Promise<any> => {
+    if (process.env.APP_ENV === 'production') {
+        await db();
         await getGISCoordinates(job.data.id);
-        await retrieveAndSaveMatchResultAsync(job.data.id);
-    })
-    .then(() => done())
-    .catch(error => {
-        console.error(error);
-        renderError(error);
-        done();
-    });
+        return await retrieveAndSaveMatchResultAsync(job.data.id);
+    } else {
+        console.log('Not sending job in staging.');
+        return;
+    }
 };

--- a/api/jobs/processors/sendNightlyEmailProcessor.ts
+++ b/api/jobs/processors/sendNightlyEmailProcessor.ts
@@ -2,6 +2,11 @@ import db from '../../models/db';
 import { sendActivityEmailToCampaignAdminsAsync } from '../../services/emailService';
 
 export default async (job: { data: any }): Promise<any> => {
-    await db();
-    return await sendActivityEmailToCampaignAdminsAsync(job.data.id);
+    if (process.env.APP_ENV === 'production') {
+        await db();
+        return await sendActivityEmailToCampaignAdminsAsync(job.data.id);
+    } else {
+        console.log('Not sending job in staging.');
+        return;
+    }
 };


### PR DESCRIPTION
Since the qa db is full of dummy data, we probably should not be sending automated emails to possible real email addresses. I'm still working on wrapping my head around `openelections-jobs`, updating documentation, reproducing prod functionality locally. Ergo, this change may be temporary once that knowledge is solidified.  