### PR TITLE
Fix Twitter image preview

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -12,7 +12,7 @@
       property="og:description"
       content="👀 Check out campaign contributions for candidates for Portland Mayor and City Council. Were they made by people or businesses? From Portland or elsewhere? How much 💰 have they raised? 🤔"
     />
-    <meta property="og:image" content="%PUBLIC_URL%/oae-sharing-preview.jpg" />
+    <meta property="og:image" content="https://qa.openelectionsportland.org/oae-sharing-preview.jpg" />
     <meta
       property="og:image:secure_url"
       content="%PUBLIC_URL%/oae-sharing-preview.jpg"
@@ -25,7 +25,9 @@
       content="The Open Elections Portland Dashboard"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@openportland" />    
+    <meta name="twitter:site" content="@openportland" />
+    <meta property="twitter:image" content="https://qa.openelectionsportland.org/oae-sharing-preview.jpg" />
+    <meta property="twitter:image-alt" content="The Open Elections Portland Dashboard" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
The Twitter card generator does not respect relative links, only full html links. See this for more details. Using QA for the images since it's already deployed.

https://twittercommunity.com/t/card-error-unable-to-render-or-no-image-read-this-first/62736