### PR TITLE
Revert "Redux devtools only in development (#1105)"

### DIFF
--- a/app/src/configureStore.js
+++ b/app/src/configureStore.js
@@ -118,13 +118,8 @@ const storeEnhancer = ReduxQuerySync.enhancer({
 
 export default function configureStore(history) {
   const composeEnhancers =
-    process.env.NODE_ENV === 'development'
-      ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
-      : compose;
-  if (
-    process.env.NODE_ENV === 'development' &&
-    !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-  ) {
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  if (!composeEnhancers) {
     console.warn(
       'Install Redux DevTools Extension to inspect the app state: ' +
         'https://github.com/zalmoxisus/redux-devtools-extension#installation'


### PR DESCRIPTION
This reverts commit 660ada07bac07c47bcd321b880a2966fca9e5904, which [failed to deploy](https://travis-ci.org/github/hackoregon/openelections/builds/723154475) and is causing tests to fail due to the error below:

`Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)`