### PR TITLE
Make occupation info optional [gh-1129]

### DIFF
--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
@@ -414,19 +414,19 @@ export const fields = {
     label: "Employer's Name",
     section: FormSectionEnum.CONTRIBUTOR,
     component: TextField,
-    validation: Yup.string(),
+    validation: Yup.string().nullable(),
   },
   employerCity: {
     label: 'City',
     section: FormSectionEnum.CONTRIBUTOR,
     component: TextField,
-    validation: Yup.string(),
+    validation: Yup.string().nullable(),
   },
   employerState: {
     label: 'State',
     section: FormSectionEnum.CONTRIBUTOR,
     component: SelectField,
-    validation: Yup.string(),
+    validation: Yup.string().nullable(),
     options: { values: stateList },
   },
   employerCountry: {
@@ -630,15 +630,16 @@ export const validate = values => {
   if (occupation === 'Employed' && visible.isPerson) {
     // If they don't have a letter then the employer fields are required
     if (isEmpty(occupationLetterDate)) {
-      if (isEmpty(employerName)) {
-        error.employerName = 'Employer name is required.';
-      }
-      if (isEmpty(employerCity)) {
-        error.employerCity = 'Employer city is required.';
-      }
-      if (isEmpty(employerState)) {
-        error.employerState = 'Employer state is required.';
-      }
+      // This is now optional
+      // if (isEmpty(employerName)) {
+      //   error.employerName = 'Employer name is required.';
+      // }
+      // if (isEmpty(employerCity)) {
+      //   error.employerCity = 'Employer city is required.';
+      // }
+      // if (isEmpty(employerState)) {
+      //   error.employerState = 'Employer state is required.';
+      // }
     }
   }
 

--- a/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
+++ b/app/src/Pages/Portal/Contributions/Utils/ContributionsFields.js
@@ -626,23 +626,6 @@ export const validate = values => {
     error.entityName = 'Name of entity is required';
   }
 
-  // They are employed and they don't have a letter require employer info
-  if (occupation === 'Employed' && visible.isPerson) {
-    // If they don't have a letter then the employer fields are required
-    if (isEmpty(occupationLetterDate)) {
-      // This is now optional
-      // if (isEmpty(employerName)) {
-      //   error.employerName = 'Employer name is required.';
-      // }
-      // if (isEmpty(employerCity)) {
-      //   error.employerCity = 'Employer city is required.';
-      // }
-      // if (isEmpty(employerState)) {
-      //   error.employerState = 'Employer state is required.';
-      // }
-    }
-  }
-
   // Uncomment next line to view conditionally visible fields
   // console.log('Conditionally Visible', visible);
   values._visibleIf = visible;


### PR DESCRIPTION
This PR makes adding employer information optional for contributions. No database updates needed.