### PR TITLE
Add OTHER option to oaeType

### DIFF
--- a/api/models/entity/Contribution.ts
+++ b/api/models/entity/Contribution.ts
@@ -98,7 +98,8 @@ export enum OaeType {
     PUBLICMATCHING = 'public_matching_contribution',
     QUALIFYING = 'qualifying',
     ALLOWABLE = 'allowable',
-    INKIND = 'inkind'
+    INKIND = 'inkind',
+    OTHER = 'other'
 }
 
 export enum PaymentMethod {

--- a/app/src/api/api.js
+++ b/app/src/api/api.js
@@ -213,6 +213,7 @@ export const OaeTypeEnum = Object.freeze({
   QUALIFYING: 'qualifying',
   ALLOWABLE: 'allowable',
   INKIND: 'inkind',
+  OTHER: 'other',
 });
 
 export const OaeTypeFieldEnum = Object.freeze({
@@ -222,6 +223,7 @@ export const OaeTypeFieldEnum = Object.freeze({
   QUALIFYING: 'Qualifying',
   ALLOWABLE: 'Allowable',
   INKIND: 'In-Kind',
+  OTHER: 'Other',
 });
 
 export const DataToOaeTypeTypeFieldMap = new Map([
@@ -234,6 +236,7 @@ export const DataToOaeTypeTypeFieldMap = new Map([
   [OaeTypeEnum.QUALIFYING, OaeTypeFieldEnum.QUALIFYING],
   [OaeTypeEnum.ALLOWABLE, OaeTypeFieldEnum.ALLOWABLE],
   [OaeTypeEnum.INKIND, OaeTypeFieldEnum.INKIND],
+  [OaeTypeEnum.OTHER, OaeTypeFieldEnum.OTHER],
 ]);
 
 export const OaeTypeFieldToDataMap = new Map([


### PR DESCRIPTION
[gh-1130]
This PR requires connecting to the database and doing an `alter type contributions_oaetype_enum add value 'other';` prior to launch.