### PR TITLE
Update date formating for date-fns change

### DIFF
--- a/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
+++ b/app/src/Pages/Portal/Contributions/ContributionsTable/ContributionsTable.js
@@ -53,7 +53,7 @@ const columns = isGovAdmin => {
           new Date(
             parseFromTimeZone(rowData.date, { timeZone: 'America/Los_Angeles' })
           ),
-          'mm-dd-yyyy'
+          'MM-dd-yyyy'
         ),
     },
     {

--- a/app/src/components/Forms/ActivityStream/ActivitySection.js
+++ b/app/src/components/Forms/ActivityStream/ActivitySection.js
@@ -125,7 +125,7 @@ const activityList = ({
                 timeZone: 'America/Los_Angeles',
               })
             ),
-            'mm-dd-yyyy @ hh:mma'
+            'MM-dd-yyyy @ hh:mma'
           );
           return (
             <li


### PR DESCRIPTION
In the last update the `format` function from `date-fns` changed, requiring the need to use `MM` instead of `mm` when returning our desired output.